### PR TITLE
feat: WebSocket 实时歌词 + SMTC 媒体选项面板 + 歌词时序优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.workbuddy

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -802,6 +802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,7 +1620,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -1679,6 +1685,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
@@ -1694,7 +1711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1705,7 +1722,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -1727,7 +1744,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "itoa",
@@ -1743,7 +1760,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1778,7 +1795,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "ipnet",
@@ -2400,6 +2417,7 @@ name = "netspeed-dynamic"
 version = "1.0.0"
 dependencies = [
  "cpal",
+ "futures-util",
  "reqwest 0.12.28",
  "rustfft",
  "serde",
@@ -2411,6 +2429,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tokio",
+ "tokio-tungstenite",
  "urlencoding",
  "winapi",
  "windows 0.58.0",
@@ -3014,6 +3033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3157,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3247,7 +3305,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3286,7 +3344,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3709,6 +3767,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,7 +4114,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.4.2",
  "jni",
  "libc",
  "log",
@@ -4218,7 +4287,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
+ "http 1.4.2",
  "jni",
  "objc2",
  "objc2-ui-kit",
@@ -4241,7 +4310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
- "http",
+ "http 1.4.2",
  "jni",
  "log",
  "objc2",
@@ -4273,7 +4342,7 @@ dependencies = [
  "dom_query",
  "dunce",
  "glob",
- "http",
+ "http 1.4.2",
  "infer",
  "json-patch",
  "log",
@@ -4477,6 +4546,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4633,7 +4714,7 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -4722,6 +4803,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"
@@ -5867,7 +5967,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http",
+ "http 1.4.2",
  "javascriptcore-rs",
  "jni",
  "libc",
@@ -5998,6 +6098,26 @@ dependencies = [
  "serde",
  "winnow 1.0.3",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,3 +51,7 @@ windows = { version = "0.58.0", features = [
 ] }
 cpal = "0.15"
 rustfft = "6.2"
+
+tokio-tungstenite = "0.20"          # WebSocket 客户端
+futures-util = "0.3"                # 流处理工具
+serde_json = "1.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,7 @@
+// ============================================================================
+// main.rs - 应用入口，整合所有模块和状态
+// ============================================================================
+
 mod audio_spectrum;
 mod music_controller;
 mod notification;
@@ -6,18 +10,20 @@ mod system_events;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 use tauri::{State, Manager, Emitter};
-use sysinfo::{Networks};
+use sysinfo::Networks;
 use std::net::{SocketAddr, TcpStream};
 use std::time::{Duration, Instant};
 use tauri_plugin_autostart::MacosLauncher;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{TrayIconBuilder, TrayIconEvent, MouseButton};
 use winapi::shared::windef::RECT;
+use tokio::sync::Mutex as TokioMutex; // 用于异步互斥锁
 
-// 全功能灵动岛智能双模动画锁
+// ----------------------------------------------------------------------------
+// 全局动画控制
+// ----------------------------------------------------------------------------
 static ANIMATION_ID: AtomicU32 = AtomicU32::new(0);
 
-// 将分散的坐标合并为一个结构体，并附带所有权 ID 防止误删
 struct AnchorState {
     center_x: i32,
     origin_y: i32,
@@ -35,22 +41,35 @@ fn force_window_topmost(app: tauri::AppHandle) {
             let fg_hwnd = winapi::um::winuser::GetForegroundWindow();
             if !fg_hwnd.is_null() {
                 let mut class_name = [0u16; 256];
-                let len = winapi::um::winuser::GetClassNameW(fg_hwnd, class_name.as_mut_ptr(), class_name.len() as i32);
+                let len = winapi::um::winuser::GetClassNameW(
+                    fg_hwnd,
+                    class_name.as_mut_ptr(),
+                    class_name.len() as i32,
+                );
                 let class_str = String::from_utf16_lossy(&class_name[..len as usize]);
-                
-                if class_str == "#32768" { return; }
+
+                if class_str == "#32768" {
+                    return;
+                }
 
                 let mut rect: RECT = std::mem::zeroed();
                 winapi::um::winuser::GetWindowRect(fg_hwnd, &mut rect);
 
-                let monitor = winapi::um::winuser::MonitorFromWindow(fg_hwnd, winapi::um::winuser::MONITOR_DEFAULTTONEAREST);
+                let monitor = winapi::um::winuser::MonitorFromWindow(
+                    fg_hwnd,
+                    winapi::um::winuser::MONITOR_DEFAULTTONEAREST,
+                );
                 let mut mi: winapi::um::winuser::MONITORINFO = std::mem::zeroed();
                 mi.cbSize = std::mem::size_of::<winapi::um::winuser::MONITORINFO>() as u32;
                 winapi::um::winuser::GetMonitorInfoW(monitor, &mut mi);
 
-                if rect.left == mi.rcMonitor.left && rect.top == mi.rcMonitor.top && rect.right == mi.rcMonitor.right && rect.bottom == mi.rcMonitor.bottom {
+                if rect.left == mi.rcMonitor.left
+                    && rect.top == mi.rcMonitor.top
+                    && rect.right == mi.rcMonitor.right
+                    && rect.bottom == mi.rcMonitor.bottom
+                {
                     if class_str != "Progman" && class_str != "WorkerW" {
-                        return; 
+                        return;
                     }
                 }
             }
@@ -64,7 +83,6 @@ fn force_window_topmost(app: tauri::AppHandle) {
     }
 }
 
-// 新增：底层原子化窗口调整指令，彻底消除位移闪烁
 #[tauri::command]
 fn set_window_bounds(app: tauri::AppHandle, x: i32, y: i32, width: i32, height: i32) {
     #[cfg(target_os = "windows")]
@@ -72,12 +90,13 @@ fn set_window_bounds(app: tauri::AppHandle, x: i32, y: i32, width: i32, height: 
         if let Some(win) = app.get_webview_window("widget") {
             if let Ok(hwnd) = win.hwnd() {
                 unsafe {
-                    // 0x0014 = SWP_NOACTIVATE (0x0010) | SWP_NOZORDER (0x0004)
-                    // 确保同时修改坐标和尺寸时，不抢占用户焦点，不打乱窗口层级
                     winapi::um::winuser::SetWindowPos(
                         hwnd.0 as _,
                         std::ptr::null_mut(),
-                        x, y, width, height,
+                        x,
+                        y,
+                        width,
+                        height,
                         0x0014,
                     );
                 }
@@ -94,7 +113,7 @@ async fn start_island_animation(
     target_width: f64,
     target_height: f64,
     is_pinned: bool,
-    spring_style: String, // 1. 👈 新增这一行，接收前端传来的参数
+    spring_style: String,
 ) -> Result<(), String> {
     let id = ANIMATION_ID.fetch_add(1, Ordering::SeqCst) + 1;
     let scale_factor = window.scale_factor().unwrap_or(1.0);
@@ -110,7 +129,7 @@ async fn start_island_animation(
 
             let (anchor_cx, anchor_cy, anchor_lx, anchor_by) = {
                 let mut anchor_guard = ANIMATION_ANCHOR.lock().unwrap_or_else(|e| e.into_inner());
-                
+
                 if let Some(anchor) = anchor_guard.as_mut() {
                     anchor.active_id = id;
                     (anchor.center_x, anchor.origin_y, anchor.left_x, anchor.bottom_y)
@@ -135,16 +154,13 @@ async fn start_island_animation(
 
             std::thread::spawn(move || {
                 let start_time = std::time::Instant::now();
-                
-                // 2. 👈 根据参数动态匹配弹性物理常数
-                // Stiff (克制): 提高频率，大幅拉高阻尼，使其快准狠
-                // Bouncy (Q弹): 保持原本欢快的震喜感
+
                 let (freq, decay, duration_ms) = if spring_style == "stiff" {
-                    (3.8, 22.0, 250) 
+                    (3.8, 22.0, 250)
                 } else {
-                    (2.4, 12.0, 400) 
+                    (2.4, 12.0, 400)
                 };
-                
+
                 let duration = std::time::Duration::from_millis(duration_ms);
 
                 while start_time.elapsed() < duration {
@@ -156,9 +172,12 @@ async fn start_island_animation(
 
                     let elapsed = start_time.elapsed().as_secs_f64();
                     let progress = elapsed / (duration_ms as f64 / 1000.0);
-                    if progress >= 1.0 { break; }
+                    if progress >= 1.0 {
+                        break;
+                    }
 
-                    let spring = 1.0 - (freq * elapsed * 2.0 * std::f64::consts::PI).cos() * (-decay * elapsed).exp();
+                    let spring =
+                        1.0 - (freq * elapsed * 2.0 * std::f64::consts::PI).cos() * (-decay * elapsed).exp();
                     let current_w = start_width + (target_width - start_width) * spring;
                     let current_h = start_height + (target_height - start_height) * spring;
 
@@ -166,13 +185,21 @@ async fn start_island_animation(
                     let phys_window_h = (current_h * scale_factor).round() as i32;
 
                     let (final_x, final_y) = if is_pinned {
-                        (anchor_lx, anchor_by - phys_window_w) // 修正原有的高度映射
+                        (anchor_lx, anchor_by - phys_window_w)
                     } else {
                         (anchor_cx - phys_window_w / 2, anchor_cy)
                     };
 
                     unsafe {
-                        SetWindowPos(hwnd_raw as _, std::ptr::null_mut(), final_x, final_y, phys_window_w, phys_window_h, 0x0014);
+                        SetWindowPos(
+                            hwnd_raw as _,
+                            std::ptr::null_mut(),
+                            final_x,
+                            final_y,
+                            phys_window_w,
+                            phys_window_h,
+                            0x0014,
+                        );
                     }
                 }
 
@@ -187,7 +214,15 @@ async fn start_island_animation(
                     };
 
                     unsafe {
-                        SetWindowPos(hwnd_raw as _, std::ptr::null_mut(), final_x, final_y, phys_target_w, phys_target_h, 0x0014);
+                        SetWindowPos(
+                            hwnd_raw as _,
+                            std::ptr::null_mut(),
+                            final_x,
+                            final_y,
+                            phys_target_w,
+                            phys_target_h,
+                            0x0014,
+                        );
                     }
                     let _ = window_clone.emit("island-resize", vec![target_width, target_height]);
 
@@ -205,10 +240,18 @@ async fn start_island_animation(
     Ok(())
 }
 
-struct AppState {
-    networks: Mutex<Networks>,
+// ----------------------------------------------------------------------------
+// 应用状态（包含网络统计和 WebSocket 任务句柄）
+// 必须 pub 以便其他模块（如 music_controller）可以访问
+// ----------------------------------------------------------------------------
+pub struct AppState {
+    pub networks: Mutex<Networks>,
+    pub ws_task: TokioMutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
+// ----------------------------------------------------------------------------
+// 网络相关命令
+// ----------------------------------------------------------------------------
 #[tauri::command]
 fn get_network_stats(state: State<'_, AppState>) -> (u64, u64) {
     let mut networks = state.networks.lock().unwrap();
@@ -245,6 +288,9 @@ fn is_widget_visible(app: tauri::AppHandle) -> bool {
     }
 }
 
+// ----------------------------------------------------------------------------
+// 主入口
+// ----------------------------------------------------------------------------
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let networks = Networks::new_with_refreshed_list();
@@ -252,8 +298,16 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {}))
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_autostart::init(MacosLauncher::LaunchAgent, Some(vec!["--autostart"])))
-        .manage(AppState { networks: Mutex::new(networks) })
+        .plugin(tauri_plugin_autostart::init(
+            MacosLauncher::LaunchAgent,
+            Some(vec!["--autostart"]),
+        ))
+        // 初始化 AppState（注意这里补上了逗号）
+        .manage(AppState {
+            networks: Mutex::new(networks),
+            ws_task: TokioMutex::new(None),
+        })
+        // 注册所有命令（包含新加的 WebSocket 命令）
         .invoke_handler(tauri::generate_handler![
             get_network_stats,
             is_widget_visible,
@@ -268,77 +322,95 @@ pub fn run() {
             music_controller::control_system_media,
             music_controller::get_random_cover_url,
             music_controller::fetch_netease_lyrics,
+            // 👇 新增 WebSocket 歌词命令
+            music_controller::start_websocket_lyrics,
+            music_controller::stop_websocket_lyrics,
         ])
         .setup(|app| {
             audio_spectrum::start_monitor();
             system_events::start_monitor(app.handle().clone());
 
-            // 全屏应用检测线程
+            // ---- 全屏检测线程（保持不变） ----
             let app_handle_for_fs = app.handle().clone();
             std::thread::spawn(move || {
-                unsafe { let _ = windows::Win32::System::Com::CoInitializeEx(None, windows::Win32::System::Com::COINIT_MULTITHREADED); }
-                
+                unsafe {
+                    let _ = windows::Win32::System::Com::CoInitializeEx(
+                        None,
+                        windows::Win32::System::Com::COINIT_MULTITHREADED,
+                    );
+                }
+
                 let mut was_fullscreen = false;
                 loop {
                     std::thread::sleep(std::time::Duration::from_millis(600));
-                    
+
                     #[cfg(target_os = "windows")]
                     {
                         unsafe {
                             let mut is_fullscreen = false;
                             let fg_hwnd = winapi::um::winuser::GetForegroundWindow();
-                            let shell_hwnd = winapi::um::winuser::GetShellWindow(); // 系统的根：explorer.exe
-                            
-                            // 1. 过滤掉无焦点窗口、桌面根节点
-                            if !fg_hwnd.is_null() 
-                                && fg_hwnd != winapi::um::winuser::GetDesktopWindow() 
-                                && fg_hwnd != shell_hwnd 
+                            let shell_hwnd = winapi::um::winuser::GetShellWindow();
+
+                            if !fg_hwnd.is_null()
+                                && fg_hwnd != winapi::um::winuser::GetDesktopWindow()
+                                && fg_hwnd != shell_hwnd
                             {
-                                // 【终极杀手锏】：获取系统外壳 (explorer.exe) 的进程 ID
                                 let mut shell_pid = 0;
                                 if !shell_hwnd.is_null() {
                                     winapi::um::winuser::GetWindowThreadProcessId(shell_hwnd, &mut shell_pid);
                                 }
 
-                                // 获取当前前景窗口的进程 ID
                                 let mut fg_pid = 0;
                                 winapi::um::winuser::GetWindowThreadProcessId(fg_hwnd, &mut fg_pid);
 
-                                // 核心判定：如果抢占焦点的窗口 PID 和任务栏/桌面是一家人
-                                // 说明这绝对是任务栏悬浮窗、音量面板或透明防误触层，直接忽略！
                                 if shell_pid != 0 && fg_pid == shell_pid {
-                                    // 属于系统外壳组件，当做无事发生
+                                    // 系统组件，忽略
                                 } else {
-                                    // 2. 进一步排除子窗口 (WS_CHILD) 和 鼠标穿透层 (WS_EX_TRANSPARENT)
-                                    let style = winapi::um::winuser::GetWindowLongPtrW(fg_hwnd, winapi::um::winuser::GWL_STYLE) as u32;
-                                    let ex_style = winapi::um::winuser::GetWindowLongPtrW(fg_hwnd, winapi::um::winuser::GWL_EXSTYLE) as u32;
-                                    
-                                    if (style & winapi::um::winuser::WS_CHILD) == 0 && (ex_style & winapi::um::winuser::WS_EX_TRANSPARENT) == 0 {
-                                        
+                                    let style = winapi::um::winuser::GetWindowLongPtrW(
+                                        fg_hwnd,
+                                        winapi::um::winuser::GWL_STYLE,
+                                    ) as u32;
+                                    let ex_style = winapi::um::winuser::GetWindowLongPtrW(
+                                        fg_hwnd,
+                                        winapi::um::winuser::GWL_EXSTYLE,
+                                    ) as u32;
+
+                                    if (style & winapi::um::winuser::WS_CHILD) == 0
+                                        && (ex_style & winapi::um::winuser::WS_EX_TRANSPARENT) == 0
+                                    {
                                         let mut class_name = [0u16; 256];
-                                        let len = winapi::um::winuser::GetClassNameW(fg_hwnd, class_name.as_mut_ptr(), class_name.len() as i32);
+                                        let len = winapi::um::winuser::GetClassNameW(
+                                            fg_hwnd,
+                                            class_name.as_mut_ptr(),
+                                            class_name.len() as i32,
+                                        );
                                         let class_str = String::from_utf16_lossy(&class_name[..len as usize]);
-                                        
-                                        // 3. 保底黑名单（防一手那些不在 explorer.exe 里的新版 UWP 系统层）
-                                        let is_blacklisted = class_str.contains("Windows.UI.Core.CoreWindow") 
+
+                                        let is_blacklisted = class_str.contains("Windows.UI.Core.CoreWindow")
                                             || class_str.contains("Xaml_WindowedPopupClass")
                                             || class_str.contains("SearchApp")
                                             || class_str.contains("NotifyIconOverflowWindow");
 
                                         if !is_blacklisted {
-                                            // 4. 几何判定：真正判断它是否铺满了屏幕
-                                            let mut rect: winapi::shared::windef::RECT = std::mem::zeroed();
+                                            let mut rect: winapi::shared::windef::RECT =
+                                                std::mem::zeroed();
                                             winapi::um::winuser::GetWindowRect(fg_hwnd, &mut rect);
 
-                                            let monitor = winapi::um::winuser::MonitorFromWindow(fg_hwnd, winapi::um::winuser::MONITOR_DEFAULTTONEAREST);
-                                            let mut mi: winapi::um::winuser::MONITORINFO = std::mem::zeroed();
-                                            mi.cbSize = std::mem::size_of::<winapi::um::winuser::MONITORINFO>() as u32;
+                                            let monitor = winapi::um::winuser::MonitorFromWindow(
+                                                fg_hwnd,
+                                                winapi::um::winuser::MONITOR_DEFAULTTONEAREST,
+                                            );
+                                            let mut mi: winapi::um::winuser::MONITORINFO =
+                                                std::mem::zeroed();
+                                            mi.cbSize = std::mem::size_of::<
+                                                winapi::um::winuser::MONITORINFO,
+                                            >() as u32;
                                             winapi::um::winuser::GetMonitorInfoW(monitor, &mut mi);
 
-                                            if rect.left <= mi.rcMonitor.left 
-                                                && rect.top <= mi.rcMonitor.top 
-                                                && rect.right >= mi.rcMonitor.right 
-                                                && rect.bottom >= mi.rcMonitor.bottom 
+                                            if rect.left <= mi.rcMonitor.left
+                                                && rect.top <= mi.rcMonitor.top
+                                                && rect.right >= mi.rcMonitor.right
+                                                && rect.bottom >= mi.rcMonitor.bottom
                                             {
                                                 is_fullscreen = true;
                                             }
@@ -347,7 +419,6 @@ pub fn run() {
                                 }
                             }
 
-                            // 状态翻转时发送信号
                             if is_fullscreen != was_fullscreen {
                                 let _ = app_handle_for_fs.emit("fullscreen-changed", is_fullscreen);
                                 was_fullscreen = is_fullscreen;
@@ -357,6 +428,7 @@ pub fn run() {
                 }
             });
 
+            // ---- 启动参数处理 ----
             let args: Vec<String> = std::env::args().collect();
             let is_autostart = args.iter().any(|arg| arg == "--autostart");
 
@@ -367,6 +439,7 @@ pub fn run() {
                 }
             }
 
+            // ---- 系统托盘 ----
             let quit_item = MenuItem::with_id(app, "quit", "强制退出", true, None::<&str>)?;
             let tray_menu = Menu::with_items(app, &[&quit_item])?;
 
@@ -375,19 +448,26 @@ pub fn run() {
                 .tooltip("NetSpeed Dynamic Pro")
                 .menu(&tray_menu)
                 .on_menu_event(move |_app_handle, event| {
-                    if event.id == "quit" { std::process::exit(0); }
+                    if event.id == "quit" {
+                        std::process::exit(0);
+                    }
                 })
                 .on_tray_icon_event(|tray, event| {
-                    if let TrayIconEvent::Click { button: MouseButton::Left, .. } = event {
+                    if let TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        ..
+                    } = event
+                    {
                         if let Some(main_window) = tray.app_handle().get_webview_window("main") {
-                            let _ = main_window.show();     
-                            let _ = main_window.unminimize(); 
-                            let _ = main_window.set_focus();  
+                            let _ = main_window.show();
+                            let _ = main_window.unminimize();
+                            let _ = main_window.set_focus();
                         }
                     }
                 })
                 .build(app)?;
 
+            // ---- 主窗口关闭时隐藏而非退出 ----
             if let Some(main_window) = app.get_webview_window("main") {
                 let w_clone = main_window.clone();
                 main_window.on_window_event(move |event| {
@@ -398,30 +478,53 @@ pub fn run() {
                 });
             }
 
+            // ---- 悬浮窗（widget）去边框和圆角 ----
             if let Some(widget_window) = app.get_webview_window("widget") {
                 #[cfg(target_os = "windows")]
                 {
                     use windows_sys::Win32::Graphics::Dwm::{
-                        DwmSetWindowAttribute, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWA_BORDER_COLOR, DWMWCP_DONOTROUND,
+                        DwmSetWindowAttribute, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWA_BORDER_COLOR,
+                        DWMWCP_DONOTROUND,
                     };
-                    use windows_sys::Win32::UI::WindowsAndMessaging::{SetWindowLongPtrW, GWL_STYLE, WS_CAPTION};
+                    use windows_sys::Win32::UI::WindowsAndMessaging::{
+                        SetWindowLongPtrW, GWL_STYLE, WS_CAPTION,
+                    };
                     use windows_sys::Win32::Foundation::HWND;
 
                     if let Ok(hwnd) = widget_window.hwnd() {
                         let hwnd_raw = hwnd.0 as HWND;
                         unsafe {
-                            let current_style = windows_sys::Win32::UI::WindowsAndMessaging::GetWindowLongPtrW(hwnd_raw, GWL_STYLE);
-                            SetWindowLongPtrW(hwnd_raw, GWL_STYLE, current_style & !(WS_CAPTION as isize));
+                            let current_style =
+                                windows_sys::Win32::UI::WindowsAndMessaging::GetWindowLongPtrW(
+                                    hwnd_raw,
+                                    GWL_STYLE,
+                                );
+                            SetWindowLongPtrW(
+                                hwnd_raw,
+                                GWL_STYLE,
+                                current_style & !(WS_CAPTION as isize),
+                            );
 
                             let border_color: u32 = 0xFFFFFFFE;
-                            let _ = DwmSetWindowAttribute(hwnd_raw, DWMWA_BORDER_COLOR as u32, &border_color as *const _ as *const _, 4);
+                            let _ = DwmSetWindowAttribute(
+                                hwnd_raw,
+                                DWMWA_BORDER_COLOR as u32,
+                                &border_color as *const _ as *const _,
+                                4,
+                            );
 
                             let corner_preference = DWMWCP_DONOTROUND;
-                            let _ = DwmSetWindowAttribute(hwnd_raw, DWMWA_WINDOW_CORNER_PREFERENCE as u32, &corner_preference as *const _ as *const _, 4);
+                            let _ = DwmSetWindowAttribute(
+                                hwnd_raw,
+                                DWMWA_WINDOW_CORNER_PREFERENCE as u32,
+                                &corner_preference as *const _ as *const _,
+                                4,
+                            );
                         }
                     }
                 }
             }
+
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src-tauri/src/music_controller.rs
+++ b/src-tauri/src/music_controller.rs
@@ -1,5 +1,5 @@
 use std::sync::Mutex;
-use tauri::command;
+use tauri::{command, Emitter};
 
 // --- 引入 SMTC 需要的模块 ---
 use windows::Media::Control::{
@@ -7,6 +7,11 @@ use windows::Media::Control::{
     GlobalSystemMediaTransportControlsSessionPlaybackStatus,
     GlobalSystemMediaTransportControlsSession,
 };
+
+// --- WebSocket 相关 ---
+use tokio_tungstenite::connect_async;
+use futures_util::StreamExt;
+use tauri::AppHandle;
 
 // 全局记录当前选中的平台（默认空，由前端传来）
 static TARGET_PLAYER: Mutex<String> = Mutex::new(String::new());
@@ -354,4 +359,70 @@ pub async fn fetch_netease_lyrics(song_name: String, artist_name: String, durati
     }
     
     Ok("".to_string())
+}
+
+// ============================================================================
+// 7. WebSocket 实时歌词推送
+// ============================================================================
+
+/// WebSocket 后台任务：连接服务器、接收歌词并转发给前端
+/// 适配 Just Solo LyricServer 协议（单向推送：init / progress / playback）
+async fn run_websocket_lyrics(
+    url: String,
+    app: AppHandle,
+) -> Result<(), String> {
+    let (ws_stream, _) = connect_async(&url)
+        .await
+        .map_err(|e| format!("WebSocket 连接失败: {}", e))?;
+    let (_sender, mut receiver) = ws_stream.split();
+
+    // LyricServer 为单向推送，无需发送任何订阅消息
+    while let Some(Ok(msg)) = receiver.next().await {
+        if let Ok(text) = msg.to_text() {
+            if let Ok(payload) = serde_json::from_str::<serde_json::Value>(text) {
+                app.emit("websocket-lyrics", &payload)
+                    .map_err(|e| format!("发送事件失败: {}", e))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// 启动 WebSocket 歌词连接（由前端调用）
+#[command]
+pub async fn start_websocket_lyrics(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, crate::AppState>,
+    url: Option<String>,
+) -> Result<(), String> {
+    let ws_url = url.unwrap_or_else(|| "ws://127.0.0.1:47290/".to_string());
+
+    let mut task_guard = state.ws_task.lock().await;
+    if let Some(handle) = task_guard.take() {
+        handle.abort();
+    }
+
+    let app_clone = app.clone();
+    let app_err = app.clone();
+    let handle = tokio::spawn(async move {
+        if let Err(e) = run_websocket_lyrics(ws_url, app_clone).await {
+            eprintln!("WebSocket 歌词任务出错: {}", e);
+            let _ = app_err.emit("websocket-error", e);
+        }
+    });
+
+    *task_guard = Some(handle);
+    Ok(())
+}
+
+/// 停止 WebSocket 歌词连接（由前端调用）
+#[command]
+pub async fn stop_websocket_lyrics(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<(), String> {
+    let mut task_guard = state.ws_task.lock().await;
+    if let Some(handle) = task_guard.take() {
+        handle.abort();
+    }
+    Ok(())
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -136,6 +136,11 @@ const messages = {
         musicBaseWidthDesc: '音乐播放时未展开的基础宽度 (默认 260px)',
         globalScale: '全局灵动岛缩放',
         globalScaleDesc: '调整灵动岛的整体显示比例 (DPI)',
+        smtcSettings: '媒体选项',
+        smtcSettingsBtn: '媒体选项',
+        homePage: '主页',
+        websocketPort: 'WebSocket 端口',
+        websocketPortDesc: '默认尝试 47290 端口获取实时歌词，失败则使用此处端口，均失败则从网络获取',
     },
     'en-US': {
         appSubtitle: 'NSD desktop Dynamic Island widget',
@@ -266,6 +271,11 @@ const messages = {
         musicBaseWidthDesc: 'Unexpanded width when music is playing (Default 260px)',
         globalScale: 'Global Island Scale',
         globalScaleDesc: 'Adjust the overall display scale (DPI)',
+        smtcSettings: 'Media Options',
+        smtcSettingsBtn: 'Media',
+        homePage: 'Home',
+        websocketPort: 'WebSocket Port',
+        websocketPortDesc: 'Defaults to 47290 for real-time lyrics, falls back to this port, then to HTTP fetch',
     },
 };
 

--- a/src/views/MainPanel.vue
+++ b/src/views/MainPanel.vue
@@ -32,8 +32,14 @@
             </div>
 
             <div class="header-controls">
-                <button class="dynamicset-btn" :class="{ 'is-active': isDynamicSet }" @click="toggleDynamicSet">
+                <button class="dynamicset-btn" :class="{ 'is-active': !isDynamicSet && !isSmtcSetting }" @click="goHome">
+                    {{ t('homePage') }}
+                </button>
+                <button class="dynamicset-btn" :class="{ 'is-active': isDynamicSet }" @click="isDynamicSet = true; isSmtcSetting = false">
                     {{ t('personalizeCenter') }}
+                </button>
+                <button class="dynamicset-btn smtc-btn" :class="{ 'is-active': isSmtcSetting }" @click="isSmtcSetting = true; isDynamicSet = false">
+                    {{ t('smtcSettingsBtn') }}
                 </button>
                 <span class="control-separator"></span>
 
@@ -49,8 +55,8 @@
 
         <hr class="divider" />
 
-        <div class="main-content" :class="{ 'dynamicset-layout': isDynamicSet }">
-            <template v-if="!isDynamicSet">
+        <div class="main-content" :class="{ 'dynamicset-layout': isDynamicSet || isSmtcSetting }">
+            <template v-if="!isDynamicSet && !isSmtcSetting">
                 <div class="card status-card">
                     <div class="card-header-row">
                         <h3>{{ t('realtimeStatus') }}</h3>
@@ -249,95 +255,6 @@
                             </transition>
                         </div>
                     </div>
-                    <div class="set-item" :class="{ 'is-dropdown-open': isPlayerDropdownOpen }">
-                        <div class="set-item-meta">
-                            <span class="set-item-title">{{ t('targetMediaPlatform') }}</span>
-                            <span class="set-item-desc">{{ t('targetMediaPlatformDesc') }}</span>
-                        </div>
-                        <div class="custom-dropdown" tabindex="0" @blur="isPlayerDropdownOpen = false">
-                            <div class="dropdown-trigger" @click="isPlayerDropdownOpen = !isPlayerDropdownOpen">
-                                <div class="current-item">
-                                    <template v-if="targetPlayer === 'netease'"><img src="../assets/musci163.svg"
-                                            class="platform-icon"> {{ t('netease') }}</template>
-                                    <template v-else-if="targetPlayer === 'spotify'"><img src="../assets/Spotify.svg"
-                                            class="platform-icon"> Spotify</template>
-                                    <template v-else-if="targetPlayer === 'apple'"><img src="../assets/applemusic.svg"
-                                            class="platform-icon"> Apple</template>
-                                    <template v-else-if="targetPlayer === 'qqmusic'"><img src="../assets/qqmusic.svg"
-                                            class="platform-icon"> {{ t('qqMusic') }}</template>
-                                    <template v-else-if="targetPlayer === 'kugou'"><img src="../assets/kugou.svg"
-                                            class="platform-icon"> {{ t('kugouMusic') }}</template>
-                                    <template v-else-if="targetPlayer === 'echo'"><img src="../assets/echomusic.ico"
-                                            class="platform-icon"> EchoMusic</template>
-                                    <template v-else-if="targetPlayer === 'lx-music'"><img src="../assets/lxmusic.png"
-                                            class="platform-icon"> {{ t('lxMusic') }}</template>
-                                    <template v-else-if="targetPlayer === 'other'">
-                                        <svg viewBox="0 0 24 24" class="platform-icon" fill="currentColor">
-                                            <path
-                                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" />
-                                        </svg>
-                                        {{ t('genericMedia') }}
-                                    </template>
-                                </div>
-                                <svg viewBox="0 0 24 24" class="arrow-icon"
-                                    :class="{ 'is-open': isPlayerDropdownOpen }">
-                                    <path d="M7 10l5 5 5-5" fill="none" stroke="currentColor" stroke-width="2"
-                                        stroke-linecap="round" />
-                                </svg>
-                            </div>
-
-                            <transition name="dropdown">
-                                <div class="dropdown-menu" v-show="isPlayerDropdownOpen">
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'netease' }"
-                                        @click="handleSelectPlayer('netease')">
-                                        <img src="../assets/musci163.svg" class="platform-icon"> {{ t('netease') }}
-                                    </div>
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'spotify' }"
-                                        @click="handleSelectPlayer('spotify')">
-                                        <img src="../assets/Spotify.svg" class="platform-icon"> Spotify
-                                    </div>
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'apple' }"
-                                        @click="handleSelectPlayer('apple')">
-                                        <img src="../assets/applemusic.svg" class="platform-icon"> Apple
-                                    </div>
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'qqmusic' }"
-                                        @click="handleSelectPlayer('qqmusic')">
-                                        <img src="../assets/qqmusic.svg" class="platform-icon"> {{ t('qqMusic') }}
-                                    </div>
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'kugou' }"
-                                        @click="handleSelectPlayer('kugou')">
-                                        <img src="../assets/kugou.svg" class="platform-icon"> {{ t('kugouMusic') }}
-                                    </div>
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'echo' }"
-                                        @click="handleSelectPlayer('echo')">
-                                        <img src="../assets/echomusic.ico" class="platform-icon"> EchoMusic
-                                    </div>
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'lx-music' }"
-                                        @click="handleSelectPlayer('lx-music')">
-                                        <img src="../assets/lxmusic.png" class="platform-icon"> {{ t('lxMusic') }}
-                                    </div>
-                                    <div class="dropdown-item" :class="{ 'is-active': targetPlayer === 'other' }"
-                                        @click="handleSelectPlayer('other')">
-                                        <svg viewBox="0 0 24 24" class="platform-icon" fill="currentColor">
-                                            <path
-                                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" />
-                                        </svg>
-                                        {{ t('otherMediaControl') }}
-                                    </div>
-                                </div>
-                            </transition>
-                        </div>
-                    </div>
-                    <div class="set-item">
-                        <div class="set-item-meta">
-                            <span class="set-item-title">{{ t('mediaController') }}</span>
-                            <span class="set-item-desc">{{ t('mediaControllerDesc') }}</span>
-                        </div>
-                        <label class="switch">
-                            <input type="checkbox" v-model="enableMusicCtrl">
-                            <span class="slider"></span>
-                        </label>
-                    </div>
                     <div class="set-item">
                         <div class="set-item-meta">
                             <span class="set-item-title">{{ t('messageNotifications') }}</span>
@@ -371,8 +288,88 @@
                 </div>
             </template>
 
-            <template v-else>
+            <template v-else-if="isDynamicSet">
                 <DynamicSet />
+            </template>
+            <template v-else>
+                <!-- SMTC 设置面板（内联，类似个性化中心） -->
+                <div class="smtc-panel">
+                    <div class="smtc-grid">
+                        <div class="neo-card smtc-platform-card">
+                            <div class="card-header">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="title-icon">
+                                    <path d="M9 18V5l12-2v13" />
+                                    <circle cx="6" cy="18" r="3" />
+                                    <circle cx="18" cy="16" r="3" />
+                                </svg>
+                                <span>{{ t('targetMediaPlatform') }}</span>
+                            </div>
+                            <span class="card-desc">{{ t('targetMediaPlatformDesc') }}</span>
+                            <div class="smtc-player-grid">
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'netease' }" @click="handleSelectPlayer('netease')">
+                                    <img src="../assets/musci163.svg" class="smtc-p-icon"><span>{{ t('netease') }}</span>
+                                </button>
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'spotify' }" @click="handleSelectPlayer('spotify')">
+                                    <img src="../assets/Spotify.svg" class="smtc-p-icon"><span>Spotify</span>
+                                </button>
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'apple' }" @click="handleSelectPlayer('apple')">
+                                    <img src="../assets/applemusic.svg" class="smtc-p-icon"><span>Apple</span>
+                                </button>
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'qqmusic' }" @click="handleSelectPlayer('qqmusic')">
+                                    <img src="../assets/qqmusic.svg" class="smtc-p-icon"><span>{{ t('qqMusic') }}</span>
+                                </button>
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'kugou' }" @click="handleSelectPlayer('kugou')">
+                                    <img src="../assets/kugou.svg" class="smtc-p-icon"><span>{{ t('kugouMusic') }}</span>
+                                </button>
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'echo' }" @click="handleSelectPlayer('echo')">
+                                    <img src="../assets/echomusic.ico" class="smtc-p-icon"><span>Echo</span>
+                                </button>
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'lx-music' }" @click="handleSelectPlayer('lx-music')">
+                                    <img src="../assets/lxmusic.png" class="smtc-p-icon"><span>{{ t('lxMusic') }}</span>
+                                </button>
+                                <button class="smtc-player-btn" :class="{ active: targetPlayer === 'other' }" @click="handleSelectPlayer('other')">
+                                    <svg viewBox="0 0 24 24" class="smtc-p-icon" fill="currentColor">
+                                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" />
+                                    </svg>
+                                    <span>{{ t('genericMedia') }}</span>
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="smtc-right">
+                            <div class="neo-card">
+                                <div class="card-header">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="title-icon">
+                                        <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+                                        <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
+                                    </svg>
+                                    <span>{{ t('mediaController') }}</span>
+                                </div>
+                                <div class="form-item">
+                                    <span class="item-desc" style="font-size:12px;">{{ t('mediaControllerDesc') }}</span>
+                                    <label class="switch">
+                                        <input type="checkbox" v-model="enableMusicCtrl">
+                                        <span class="slider"></span>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <div class="neo-card" v-if="targetPlayer === 'other'">
+                                <div class="card-header">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="title-icon">
+                                        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                                        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                                    </svg>
+                                    <span>{{ t('websocketPort') }}</span>
+                                </div>
+                                <div class="smtc-port-row">
+                                    <input class="smtc-port-input" type="number" v-model.number="websocketPort" min="1024" max="65535" placeholder="47290" />
+                                </div>
+                                <span class="smtc-port-desc">{{ t('websocketPortDesc') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </template>
         </div>
 
@@ -443,6 +440,11 @@ const downloadSpeed = ref('0 B/s');
 const appVersion = ref('1.0.0');
 
 const isDynamicSet = ref(false);
+const isSmtcSetting = ref(false);
+const websocketPort = ref(Number(localStorage.getItem('nsd_ws_port')) || 47290);
+watch(websocketPort, (val) => {
+    localStorage.setItem('nsd_ws_port', String(val));
+});
 
 const isChecking = ref(false);
 const hasNewVersion = ref(false);
@@ -454,7 +456,7 @@ const setTargetPlayer = async (player: string) => {
     targetPlayer.value = player;
     localStorage.setItem('nsd_target_player', player); // 本地记忆化
     try {
-        await invoke('set_target_player', { player }); // 秒发给 Rust 立即生效
+        await invoke('set_target_player', { player });
     } catch (e) {
         console.error('切换平台失败', e);
     }
@@ -616,8 +618,9 @@ const toggleMsgNotify = () => {
 };
 
 // 切换灵动岛设置
-const toggleDynamicSet = () => {
-    isDynamicSet.value = !isDynamicSet.value;
+const goHome = () => {
+    isDynamicSet.value = false;
+    isSmtcSetting.value = false;
 };
 
 // 切换自动隐藏
@@ -2388,5 +2391,162 @@ input:disabled+.slider {
 .panel-footer {
     position: relative;
     z-index: 1;
+}
+
+/* ================================================================
+   SMTC 设置面板（内联，与个性化中心一致）
+   ================================================================ */
+.smtc-btn {
+    margin-left: 6px;
+}
+
+.smtc-panel {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.smtc-panel .neo-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.2s, border-color 0.2s;
+}
+
+.smtc-panel .card-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--item-title-color);
+    margin-bottom: 8px;
+}
+
+.smtc-panel .title-icon {
+    width: 16px;
+    height: 16px;
+    color: var(--item-desc-color);
+}
+
+.smtc-panel .form-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.smtc-panel {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.smtc-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    height: 100%;
+    align-content: start;
+}
+
+.card-desc {
+    font-size: 12px;
+    color: var(--item-desc-color, #888);
+    margin-bottom: 12px;
+}
+
+.smtc-right {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.smtc-player-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 6px;
+    margin-top: auto;
+}
+
+.smtc-player-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+    background: var(--bg-body, rgba(255,255,255,0.03));
+    border: 1px solid var(--control-border);
+    border-radius: 10px;
+    color: var(--btn-sec-color);
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.2s;
+}
+
+.smtc-player-btn:hover {
+    background: var(--btn-pri-bg);
+    border-color: var(--btn-pri-border);
+    color: var(--btn-pri-color);
+}
+
+.smtc-player-btn.active {
+    background: var(--btn-pri-bg);
+    border-color: var(--btn-pri-border);
+    color: var(--btn-pri-color);
+    box-shadow: 0 0 12px rgba(74, 158, 255, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);
+    transform: scale(1.03);
+    font-weight: 600;
+}
+
+.smtc-p-icon {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+
+.smtc-port-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.smtc-port-input {
+    width: 120px;
+    padding: 8px 12px;
+    background: var(--bg-body, rgba(0,0,0,0.3));
+    border: 1px solid var(--control-border);
+    border-radius: 8px;
+    color: var(--item-title-color);
+    font-size: 14px;
+    font-family: ui-monospace, monospace;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.smtc-port-input:focus {
+    border-color: var(--btn-pri-border, #4a9eff);
+}
+
+.smtc-port-input::placeholder {
+    color: var(--item-desc-color, #666);
+    font-size: 12px;
+}
+
+.smtc-port-input::-webkit-outer-spin-button,
+.smtc-port-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.smtc-port-desc {
+    font-size: 11px;
+    color: var(--item-desc-color, #888);
+    line-height: 1.4;
+    margin-top: 6px;
 }
 </style>

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -361,6 +361,10 @@ const lyricQueue = ref<string[]>([]);
 let lastLyricChangeTime = 0;
 let currentMatchedIndex = -1;
 
+// WebSocket 歌词连接状态
+let wsUnlisten: (() => void) | null = null;
+let wsPhase = 0; // 0=未连接, 1=尝试47290, 2=尝试自定义端口, 3=HTTP兜底
+
 // 简单的 LRC 解析器
 const parseLrc = (lrcStr: string) => {
     const lines = lrcStr.split('\n');
@@ -490,13 +494,111 @@ const nextTrack = async () => {
     await invoke('control_system_media', { action: 'next' });
 };
 
+// ============================================================================
+// WebSocket 歌词连接（降级：47290 → 自定义端口 → HTTP）
+// ============================================================================
+const fallbackHttpLyrics = async () => {
+    console.log('[WS] 降级到 HTTP 获取歌词');
+    wsPhase = 3;
+    disconnectWebSocket();
+    if (currentSongName.value) {
+        try {
+            const lrc = await invoke<string>('fetch_netease_lyrics', {
+                songName: currentSongName.value,
+                artistName: currentArtistName.value,
+                durationMs: 0
+            });
+            if (lrc) parsedLyrics.value = parseLrc(lrc);
+        } catch (_) {}
+    }
+};
+
+const connectWebSocketLyrics = async () => {
+    // 先清理旧连接
+    try { await invoke('stop_websocket_lyrics'); } catch (_) {}
+    if (wsUnlisten) { wsUnlisten(); wsUnlisten = null; }
+
+    // 监听 WebSocket 事件
+    wsUnlisten = await listen<any>('websocket-lyrics', (event) => {
+        const msg = event.payload;
+        switch (msg.type) {
+            case 'init':
+                // 服务端下发了完整歌词时间轴
+                if (msg.lyrics && msg.lyrics.length > 0) {
+                    parsedLyrics.value = msg.lyrics.map((l: any) => ({
+                        time: l.time,
+                        text: l.text
+                    }));
+                    console.log('[WS] 收到歌词:', parsedLyrics.value.length, '行');
+                } else {
+                    // 歌词为空（纯音乐等），降级 HTTP
+                    console.log('[WS] 无歌词（空数组），降级 HTTP');
+                    fallbackHttpLyrics();
+                }
+                break;
+            case 'progress':
+                // 服务端推送当前播放位置
+                localPositionMs.value = msg.position;
+                break;
+            case 'playback':
+                isPlaying.value = (msg.status === 'playing');
+                break;
+        }
+    });
+
+    // 同时监听错误事件：47290 失败 → 尝试自定义端口 → HTTP 兜底
+    const unlistenErr = await listen<string>('websocket-error', async (event) => {
+        console.warn('[WS] 错误:', event.payload);
+
+        if (wsPhase === 1) {
+            // 47290 失败了，尝试用户自定义端口
+            const customPort = localStorage.getItem('nsd_ws_port') || '47290';
+            if (customPort !== '47290') {
+                console.log('[WS] 尝试自定义端口:', customPort);
+                wsPhase = 2;
+                try {
+                    await invoke('start_websocket_lyrics', { url: `ws://127.0.0.1:${customPort}/` });
+                    console.log('[WS] 已连接自定义端口');
+                    return;
+                } catch (_) {
+                    console.warn('[WS] 自定义端口也失败');
+                }
+            }
+        }
+
+        // 都失败，降级 HTTP
+        fallbackHttpLyrics();
+    });
+
+    // 保存 error 监听器以便后续清理
+    const origUnlisten = wsUnlisten;
+    wsUnlisten = () => { origUnlisten(); unlistenErr(); };
+
+    // 默认先连 47290，失败则 websocket-error 里尝试自定义端口
+    wsPhase = 1;
+    const firstUrl = 'ws://127.0.0.1:47290/';
+    console.log('[WS] 尝试连接', firstUrl);
+    try {
+        await invoke('start_websocket_lyrics', { url: firstUrl });
+    } catch (e) {
+        console.warn('[WS] invoke 异常:', e);
+    }
+};
+
+// 断开 WebSocket
+const disconnectWebSocket = async () => {
+    try { await invoke('stop_websocket_lyrics'); } catch (_) {}
+    if (wsUnlisten) { wsUnlisten(); wsUnlisten = null; }
+    wsPhase = 0;
+};
+
 // 核心同步函数：负责获取状态并智能降级
 const syncMusicStatus = async () => {
     try {
         const res = await invoke<[string, string, boolean, number, number] | null>('fetch_netease_music_info');
 
         if (res) {
-            const [song, artist, playing, positionMs, durationMs] = res;
+            const [song, artist, playing, positionMs, _durationMs] = res;
 
             if (!isMediaActive.value) isMediaActive.value = true;
             isFirstMediaCheck = false;
@@ -537,10 +639,8 @@ const syncMusicStatus = async () => {
                         }).catch(() => { coverUrl.value = ''; });
                 }
 
-                invoke<string>('fetch_netease_lyrics', { songName: song, artistName: artist, durationMs })
-                    .then(lrc => {
-                        if (lrc) parsedLyrics.value = parseLrc(lrc);
-                    }).catch(() => { console.log('未找到歌词'); });
+                // 通过 WebSocket 获取实时歌词（失败自动降级 HTTP）
+                connectWebSocketLyrics();
             } else {
                 // 核心 2：是同一首歌，正在播放中！
                 // 缩紧容错率：只要误差超过 800ms 就立刻强制同步。
@@ -556,12 +656,16 @@ const syncMusicStatus = async () => {
                 setSafeTrackInfo(currentBaseInfo.value);
             }
         } else {
+            currentBaseInfo.value = '';
             setSafeTrackInfo(`${t('noSongPlaying')} - ${getPlayerName()}`);
             isPlaying.value = false;
-            coverUrl.value = '';
 
             if (isMediaActive.value) {
                 isMediaActive.value = false;
+                coverUrl.value = '';
+
+                // 断开 WebSocket 歌词连接
+                disconnectWebSocket();
 
                 if (isNewlyEnabled) {
                     showToast('已开启媒体控制，暂无音频播放', 'sys');
@@ -1539,7 +1643,10 @@ onMounted(async () => {
 
         if (isPlaying.value) {
             // 1. 播放状态下，本地时钟疯狂往前推算
-            localPositionMs.value += delta;
+            // WS 连接时由服务端推送进度，本地不再累加（避免双源叠加导致过快）
+            if (wsPhase < 1) {
+                localPositionMs.value += delta;
+            }
 
             // 2. 毫秒级歌词匹配与队列逻辑 (解决快节奏吞字、闪烁消失问题)
             if (parsedLyrics.value.length > 0) {
@@ -1548,7 +1655,9 @@ onMounted(async () => {
                 // 找出当前时间进度应该播放哪一句
                 for (let i = 0; i < parsedLyrics.value.length; i++) {
                     // 抢跑 550ms：完美抵消 150ms 叠化动画 + 100ms 滤镜模糊 + 听觉视觉生理时差
-                    if (parsedLyrics.value[i].time <= localPositionMs.value + 550) {
+                    // WS 模式下服务端推送精准位置，仅需 150ms 动画补偿
+                    const lead = wsPhase < 1 ? 550 : 150;
+                    if (parsedLyrics.value[i].time <= localPositionMs.value + lead) {
                         matchedIndex = i;
                     } else {
                         break;
@@ -1624,6 +1733,7 @@ onUnmounted(() => {
     clearInterval(notifyTimer);
     clearInterval(spectrumTimer);
     if (speedCycleTimer) clearInterval(speedCycleTimer);
+    disconnectWebSocket();
 });
 </script>
 


### PR DESCRIPTION
## 新增
- **WebSocket 歌词推送**
  - Rust 端：`start_websocket_lyrics` / `stop_websocket_lyrics` 命令
  - 适配 Just Solo LyricServer 协议（init / progress / playback 单向推送）
  - 默认连接 ws://127.0.0.1:47290/，支持自定义端口
  - `AppState` 新增 `ws_task` 字段管理后台任务
  - 连接失败时 emit `websocket-error` 事件供前端降级

- **SMTC / 媒体选项面板**
  - 标题栏新增「主页」「个性化中心」「媒体选项」三按钮，互斥切换
  - 媒体选项面板（内联，非弹窗）：
    - 8 个音乐平台按钮网格（网易云/Spotify/Apple/QQ/酷狗/Echo/洛雪/通用）
    - 媒体控制器开关（从底部网格移入）
    - WebSocket 端口输入框（仅「通用媒体」时显示）
    - 标签和描述文案随平台动态切换

- **i18n**：新增 smtcSettings / smtcSettingsBtn / homePage / websocketPort 等中英文翻译

## 前端歌词降级链路
- WidgetIsland 切歌时自动连接 WebSocket
- 降级顺序：47290 默认端口 → 用户自定义端口 → HTTP 网络获取
- WS 收到空歌词（init []）自动降级 HTTP
- WS 失败时 emit `websocket-error` 事件，前端监听后重试自定义端口或切 HTTP
- WS 活跃时暂停本地时钟累加（避免双源叠加导致歌词过快）
- WS 模式歌词抢跑从 550ms 降到 150ms（服务端推送精准位置）

## 修复
- 切平台时封面被误清 → `coverUrl` 清空仅在 `isMediaActive` true→false 时触发
- 停播后复播同一首歌封面不刷新 → `currentBaseInfo` 置空确保重新获取
- 歌词过快 → WS 活跃时跳过本地时钟累加
- Rust `AppHandle` borrow after move → 双 clone 分别用于 WS 任务和错误 emit
- `emit_all` → `emit` + 补充 `use tauri::Emitter`
- 移除未使用变量：`getTargetPlayer` / `durationMs`

## 依赖
- Cargo.toml: 新增 `tokio-tungstenite`、`futures-util`、`serde_json`