### PR TITLE
优化灵动岛封面与歌词的获取及窗口交互逻辑

### DIFF
--- a/src-tauri/src/music_controller.rs
+++ b/src-tauri/src/music_controller.rs
@@ -415,7 +415,100 @@ pub async fn fetch_netease_lyrics(
         .build()
         .map_err(|e| e.to_string())?;
 
-    // ENGINE 1: LRCLIB (精确匹配，自带极高校验度)
+    let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36";
+    let query = format!("{} {}", song_name, artist_name);
+    let query_name_lower = song_name.to_lowercase();
+    let query_artist_lower = artist_name.to_lowercase(); // 新增：歌手小写比对
+
+    // ENGINE 1: QQ MUSIC (极速国内优选源)
+    let qq_search_url = format!(
+        "https://c.y.qq.com/soso/fcgi-bin/client_search_cp?w={}&n=5&format=json",
+        urlencoding::encode(&query)
+    );
+
+    if let Ok(resp) = client
+        .get(&qq_search_url)
+        .header("User-Agent", ua)
+        .send()
+        .await
+    {
+        if let Ok(json) = resp.json::<serde_json::Value>().await {
+            if let Some(songs) = json.pointer("/data/song/list").and_then(|v| v.as_array()) {
+                let mut best_songmid = None;
+
+                for song in songs {
+                    let songmid = song.get("songmid").and_then(|v| v.as_str());
+                    let interval = song.get("interval").and_then(|v| v.as_i64()).unwrap_or(0);
+                    let name = song
+                        .get("songname")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_lowercase();
+
+                    // 提取 QQ 音乐歌手名
+                    let mut singer_name = String::new();
+                    if let Some(singers) = song.get("singer").and_then(|v| v.as_array()) {
+                        for s in singers {
+                            if let Some(sname) = s.get("name").and_then(|v| v.as_str()) {
+                                singer_name.push_str(&sname.to_lowercase());
+                            }
+                        }
+                    }
+
+                    let name_match =
+                        name.contains(&query_name_lower) || query_name_lower.contains(&name);
+                    let artist_match = singer_name.contains(&query_artist_lower)
+                        || query_artist_lower.contains(&singer_name)
+                        || query_artist_lower.is_empty();
+
+                    if let Some(mid) = songmid {
+                        if duration_ms > 0 {
+                            let diff = (interval * 1000 - duration_ms).abs();
+                            // 核心修复：必须名字匹配，且 (歌手匹配 或 时间误差极小)
+                            if name_match && (artist_match || diff <= 3000) {
+                                best_songmid = Some(mid.to_string());
+                                break;
+                            }
+                        } else if name_match && artist_match {
+                            best_songmid = Some(mid.to_string());
+                            break;
+                        }
+                    }
+                }
+
+                if let Some(songmid) = best_songmid {
+                    let qq_lyric_url = format!("https://c.y.qq.com/lyric/fcgi-bin/fcg_query_lyric_new.fcg?songmid={}&format=json&nobase64=1", songmid);
+                    if let Ok(lyric_resp) = client
+                        .get(&qq_lyric_url)
+                        .header("Referer", "https://y.qq.com/")
+                        .header("User-Agent", ua)
+                        .send()
+                        .await
+                    {
+                        if let Ok(lyric_json) = lyric_resp.json::<serde_json::Value>().await {
+                            if let Some(lyric_text) =
+                                lyric_json.get("lyric").and_then(|v| v.as_str())
+                            {
+                                let decoded = lyric_text
+                                    .replace("&#10;", "\n")
+                                    .replace("&#13;", "\r")
+                                    .replace("&#32;", " ")
+                                    .replace("&#45;", "-")
+                                    .replace("&#40;", "(")
+                                    .replace("&#41;", ")");
+                                if !decoded.is_empty() {
+                                    println!("[网络歌词调试] 命中引擎 3: QQ音乐 API (已通过完美双重校验)");
+                                    return Ok(decoded);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ENGINE 2: LRCLIB (精确匹配，自带极高校验度)
     let duration_sec = duration_ms / 1000;
     if duration_sec > 0 {
         let lrclib_url = format!(
@@ -438,12 +531,7 @@ pub async fn fetch_netease_lyrics(
         }
     }
 
-    let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36";
-    let query = format!("{} {}", song_name, artist_name);
-    let query_name_lower = song_name.to_lowercase();
-    let query_artist_lower = artist_name.to_lowercase(); // 新增：歌手小写比对
-
-    // ENGINE 2: NETEASE FALLBACK (网易云兜底)
+    // ENGINE 3: NETEASE FALLBACK (网易云兜底)
     let fake_ip = {
         use rand::Rng;
         let mut rng = rand::thread_rng();
@@ -542,94 +630,6 @@ pub async fn fetch_netease_lyrics(
                             {
                                 println!("[网络歌词调试] 命中引擎 2: 网易云 API 兜底 (已通过完美双重校验)");
                                 return Ok(lyric_text.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // ENGINE 3: QQ MUSIC (极速国内优选源)
-    let qq_search_url = format!(
-        "https://c.y.qq.com/soso/fcgi-bin/client_search_cp?w={}&n=5&format=json",
-        urlencoding::encode(&query)
-    );
-
-    if let Ok(resp) = client
-        .get(&qq_search_url)
-        .header("User-Agent", ua)
-        .send()
-        .await
-    {
-        if let Ok(json) = resp.json::<serde_json::Value>().await {
-            if let Some(songs) = json.pointer("/data/song/list").and_then(|v| v.as_array()) {
-                let mut best_songmid = None;
-
-                for song in songs {
-                    let songmid = song.get("songmid").and_then(|v| v.as_str());
-                    let interval = song.get("interval").and_then(|v| v.as_i64()).unwrap_or(0);
-                    let name = song
-                        .get("songname")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_lowercase();
-
-                    // 提取 QQ 音乐歌手名
-                    let mut singer_name = String::new();
-                    if let Some(singers) = song.get("singer").and_then(|v| v.as_array()) {
-                        for s in singers {
-                            if let Some(sname) = s.get("name").and_then(|v| v.as_str()) {
-                                singer_name.push_str(&sname.to_lowercase());
-                            }
-                        }
-                    }
-
-                    let name_match =
-                        name.contains(&query_name_lower) || query_name_lower.contains(&name);
-                    let artist_match = singer_name.contains(&query_artist_lower)
-                        || query_artist_lower.contains(&singer_name)
-                        || query_artist_lower.is_empty();
-
-                    if let Some(mid) = songmid {
-                        if duration_ms > 0 {
-                            let diff = (interval * 1000 - duration_ms).abs();
-                            // 核心修复：必须名字匹配，且 (歌手匹配 或 时间误差极小)
-                            if name_match && (artist_match || diff <= 3000) {
-                                best_songmid = Some(mid.to_string());
-                                break;
-                            }
-                        } else if name_match && artist_match {
-                            best_songmid = Some(mid.to_string());
-                            break;
-                        }
-                    }
-                }
-
-                if let Some(songmid) = best_songmid {
-                    let qq_lyric_url = format!("https://c.y.qq.com/lyric/fcgi-bin/fcg_query_lyric_new.fcg?songmid={}&format=json&nobase64=1", songmid);
-                    if let Ok(lyric_resp) = client
-                        .get(&qq_lyric_url)
-                        .header("Referer", "https://y.qq.com/")
-                        .header("User-Agent", ua)
-                        .send()
-                        .await
-                    {
-                        if let Ok(lyric_json) = lyric_resp.json::<serde_json::Value>().await {
-                            if let Some(lyric_text) =
-                                lyric_json.get("lyric").and_then(|v| v.as_str())
-                            {
-                                let decoded = lyric_text
-                                    .replace("&#10;", "\n")
-                                    .replace("&#13;", "\r")
-                                    .replace("&#32;", " ")
-                                    .replace("&#45;", "-")
-                                    .replace("&#40;", "(")
-                                    .replace("&#41;", ")");
-                                if !decoded.is_empty() {
-                                    println!("[网络歌词调试] 命中引擎 3: QQ音乐 API (已通过完美双重校验)");
-                                    return Ok(decoded);
-                                }
                             }
                         }
                     }

--- a/src-tauri/src/music_controller.rs
+++ b/src-tauri/src/music_controller.rs
@@ -290,9 +290,13 @@ pub async fn get_smtc_cover() -> Result<Option<String>, String> {
 pub async fn get_random_cover_url(
     song_name: String,
     artist_name: String,
+    prefer_smtc: Option<bool>,
 ) -> Result<String, String> {
-    if let Some(base64_cover) = get_smtc_thumbnail() {
-        return Ok(base64_cover);
+    // 默认优先用 SMTC 本地封面；PotPlayer 音乐模式等场景前端会显式传 prefer_smtc=false 强制走网络封面
+    if prefer_smtc.unwrap_or(true) {
+        if let Some(base64_cover) = get_smtc_thumbnail() {
+            return Ok(base64_cover);
+        }
     }
 
     let client = reqwest::Client::builder()

--- a/src-tauri/src/music_controller.rs
+++ b/src-tauri/src/music_controller.rs
@@ -414,6 +414,7 @@ pub async fn fetch_netease_lyrics(
     artist_name: String,
     duration_ms: i64,
 ) -> Result<String, String> {
+    
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(4))
         .build()
@@ -512,30 +513,7 @@ pub async fn fetch_netease_lyrics(
         }
     }
 
-    // ENGINE 2: LRCLIB (精确匹配，自带极高校验度)
-    let duration_sec = duration_ms / 1000;
-    if duration_sec > 0 {
-        let lrclib_url = format!(
-            "https://lrclib.net/api/get?track_name={}&artist_name={}&duration={}",
-            urlencoding::encode(&song_name),
-            urlencoding::encode(&artist_name),
-            duration_sec
-        );
-
-        if let Ok(resp) = client.get(&lrclib_url).send().await {
-            if let Ok(json) = resp.json::<serde_json::Value>().await {
-                if let Some(synced_lyrics) = json.pointer("/syncedLyrics").and_then(|v| v.as_str())
-                {
-                    if !synced_lyrics.is_empty() {
-                        println!("[网络歌词调试] 命中引擎 1: LRCLIB API 精确匹配");
-                        return Ok(synced_lyrics.to_string());
-                    }
-                }
-            }
-        }
-    }
-
-    // ENGINE 3: NETEASE FALLBACK (网易云兜底)
+    // ENGINE 2: NETEASE FALLBACK (网易云兜底)
     let fake_ip = {
         use rand::Rng;
         let mut rng = rand::thread_rng();
@@ -636,6 +614,29 @@ pub async fn fetch_netease_lyrics(
                                 return Ok(lyric_text.to_string());
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    // ENGINE 3: LRCLIB (精确匹配，自带极高校验度)
+    let duration_sec = duration_ms / 1000;
+    if duration_sec > 0 {
+        let lrclib_url = format!(
+            "https://lrclib.net/api/get?track_name={}&artist_name={}&duration={}",
+            urlencoding::encode(&song_name),
+            urlencoding::encode(&artist_name),
+            duration_sec
+        );
+
+        if let Ok(resp) = client.get(&lrclib_url).send().await {
+            if let Ok(json) = resp.json::<serde_json::Value>().await {
+                if let Some(synced_lyrics) = json.pointer("/syncedLyrics").and_then(|v| v.as_str())
+                {
+                    if !synced_lyrics.is_empty() {
+                        println!("[网络歌词调试] 命中引擎 1: LRCLIB API 精确匹配");
+                        return Ok(synced_lyrics.to_string());
                     }
                 }
             }

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -299,6 +299,18 @@ watch(isIslandVisible, (newVal) => {
     emit('island-status-sync', { visible: newVal });
 });
 
+// 兜底保险：OS 窗口显隐必须严格跟随灵动岛状态。
+// 防止“窗体(v-show)已隐藏但透明窗口仍残留”导致该区域拦截鼠标点击
+watch(isIslandVisible, (visible) => {
+    if (visible) return;
+    // 等离开动画播完（约 350ms）再物理隐藏窗口；期间若又被呼出则放弃隐藏
+    setTimeout(() => {
+        if (!isIslandVisible.value) {
+            getCurrentWindow().hide().catch(() => { });
+        }
+    }, 400);
+}, { immediate: true });
+
 // 记录全屏自动隐藏开关状态
 const isAutoHideEnabled = ref(localStorage.getItem('nsd_autohide_fs') === 'true');
 // 记录进入全屏前的灵动岛显隐状态，用来决定退回桌面时要不要恢复
@@ -1641,6 +1653,9 @@ const adjustWindowPosition = async () => {
     } catch (error) {
         console.error('调整窗口位置失败:', error);
     } finally {
+        // 仅当灵动岛处于显示状态时才拉起透明窗口；
+        // 否则空窗口会残留并拦截该区域的鼠标点击（窗体隐藏 ≠ 窗口隐藏）
+        if (!isIslandVisible.value) return;
         try {
             await invoke('show_window_no_activate', { label: 'widget' });
         } catch (e) {

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -579,6 +579,8 @@ const coverCache = new Map<string, string>();
 // 当前播放器是否为浏览器（edge/chrome），以及是否正在展示 SMTC 本地封面
 const currentIsBrowser = ref(false);
 const isSmtcCoverActive = ref(false);
+// 当前 SMTC 来源应用的包名（用于 PotPlayer 音乐模式等封面策略判断）
+const currentAppIdStr = ref('');
 
 // 沉浸模式专属的静态模糊封面
 const blurredCoverUrl = ref('');
@@ -608,7 +610,7 @@ const bakeBlurImage = (url: string): Promise<string> => {
 // 共享的封面获取/应用逻辑：查缓存 → 未命中就调接口 → 写缓存 → 烘焙模糊封面
 // onlyIfChanged: 与当前显示的封面对比，不一样才应用（恢复播放时用）
 // clearOnError: 获取失败时是否清空封面（切歌时清空，恢复播放时保留）
-const fetchAndApplyCover = async (trackInfo: string, song: string, artist: string, onlyIfChanged = false, clearOnError = true) => {
+const fetchAndApplyCover = async (trackInfo: string, song: string, artist: string, onlyIfChanged = false, clearOnError = true, preferSmtc = true) => {
     if (coverCache.has(trackInfo)) {
         const cached = coverCache.get(trackInfo)!;
         if (!onlyIfChanged || cached !== coverUrl.value) {
@@ -618,7 +620,8 @@ const fetchAndApplyCover = async (trackInfo: string, song: string, artist: strin
         return;
     }
     try {
-        const url = await invoke<string>('get_random_cover_url', { songName: song, artistName: artist });
+        console.log("尝试获取封面");
+        const url = await invoke<string>('get_random_cover_url', { songName: song, artistName: artist, preferSmtc });
         if (!onlyIfChanged || url !== coverUrl.value) {
             coverUrl.value = url;
             if (coverCache.size > 50) {
@@ -629,6 +632,7 @@ const fetchAndApplyCover = async (trackInfo: string, song: string, artist: strin
             const bakedImage = await bakeBlurImage(url);
             blurredCoverUrl.value = bakedImage;
             blurredCoverCache.set(trackInfo, bakedImage);
+            console.log("获取封面成功");
         }
     } catch (e) {
         if (clearOnError) {
@@ -1006,7 +1010,8 @@ const refreshCoverOnResume = async () => {
             await fetchAndApplySmtcCover(trackInfo, true);
         } else {
             // 与当前显示的封面对比，不一样才更新；失败时保持现有封面不动
-            await fetchAndApplyCover(trackInfo, song, artist, true, false);
+            // PotPlayer 音乐模式同样忽略 SMTC 封面，恢复播放时仍走网络获取
+            await fetchAndApplyCover(trackInfo, song, artist, true, false, !currentAppIdStr.value.includes("potplayer"));
         }
     } finally {
         isCoverRefreshing = false;
@@ -1035,6 +1040,17 @@ const syncMusicStatus = async () => {
             // 记录当前是否为浏览器类应用（edge/chrome），供封面刷新逻辑区分处理
             currentIsBrowser.value =
                 app_id_str.includes("edge") || app_id_str.includes("chrome");
+            // 检测 SMTC 来源应用是否发生了切换（应用包名变更），用于及时刷新歌词
+            const appSwitched = currentAppIdStr.value !== '' && currentAppIdStr.value !== app_id_str;
+            // 记录当前 SMTC 来源应用的包名，供恢复播放时的封面刷新逻辑判断
+            currentAppIdStr.value = app_id_str;
+
+            // 切换 SMTC 来源应用：立即清空旧应用残留的歌词，避免串歌词（新应用歌词就绪前先显示标题）
+            if (appSwitched) {
+                parsedLyrics.value = [];
+                lyricQueue.value = [];
+                currentMatchedIndex = -1;
+            }
 
             // 仅在 WS 不活跃时，使用 SMTC 的播放状态
             if (!isWsActive) {
@@ -1097,12 +1113,13 @@ const syncMusicStatus = async () => {
                     isSmtcCoverActive.value = false;
                     coverUrl.value = APP_COVER_LOGO_MAP[app_id_str.includes("edge") ? "edge" : "chrome"];
                     fetchAndApplySmtcCover(newTrackInfo);
-                } else if (!app_id_str.includes("bilibili")) {
-                    fetchAndApplyCover(newTrackInfo, song, artist);
-                }
-
-                if (app_id_str.includes("potplayer") && artist !== "potplayer") {
-                    fetchAndApplyCover(newTrackInfo, song, artist);
+                } else if (!app_id_str.includes("bilibili") && artist !== "potplayer") {
+                    if (app_id_str.includes("potplayer")) {
+                        // PotPlayer 音乐模式：忽略 SMTC 封面，强制走网络获取
+                        isSmtcCoverActive.value = false;
+                    }
+                    fetchAndApplyCover(newTrackInfo, song, artist, false, true, !app_id_str.includes("potplayer"));
+                    console.log("获取封面ing");
                 }
 
                 if (!app_id_str.includes("potplayer")) {
@@ -1118,6 +1135,7 @@ const syncMusicStatus = async () => {
                     }
                 } else {
                     if (artist == "potplayer") { // PotPlayer视频模式
+                        console.log("直接使用PotPlayerLogo");
                         coverUrl.value = potplayerLogo;
                         // 清除上个封面的缓存与沉浸背景：防止 coverglass 背景残留上一首歌的模糊封面
                         blurredCoverUrl.value = '';
@@ -1128,10 +1146,11 @@ const syncMusicStatus = async () => {
                 }
 
                 // 仅在 WS 不活跃时，发起 HTTP 网络歌词兜底（PotPlayer 不拉歌词，标题常驻）
-                if (!isWsActive && !isPotplayerSource.value) {
+                // 切换 SMTC 应用后 WS 心跳可能仍属于旧应用，此时也立即用 HTTP 兜底，保证新歌歌词及时到位
+                if ((!isWsActive || appSwitched) && !isPotplayerSource.value) {
                     invoke<string>('fetch_netease_lyrics', { songName: song, artistName: artist, durationMs })
                         .then(lrc => {
-                            if (Date.now() - lastWsLyricTime > 3000) {
+                            if (appSwitched || Date.now() - lastWsLyricTime > 3000) {
                                 if (lrc) {
                                     parsedLyrics.value = parseLrc(lrc);
                                     // 刚拉到歌词时，如果发现时长还是 0，立刻补救

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -1097,7 +1097,11 @@ const syncMusicStatus = async () => {
                     isSmtcCoverActive.value = false;
                     coverUrl.value = APP_COVER_LOGO_MAP[app_id_str.includes("edge") ? "edge" : "chrome"];
                     fetchAndApplySmtcCover(newTrackInfo);
-                } else if (!app_id_str.includes("bilibili") && artist !== "potplayer") {
+                } else if (!app_id_str.includes("bilibili")) {
+                    fetchAndApplyCover(newTrackInfo, song, artist);
+                }
+
+                if (app_id_str.includes("potplayer") && artist !== "potplayer") {
                     fetchAndApplyCover(newTrackInfo, song, artist);
                 }
 
@@ -1113,13 +1117,14 @@ const syncMusicStatus = async () => {
                         }
                     }
                 } else {
-                    console.log(app_id_str);
-                    coverUrl.value = potplayerLogo;
-                    // 清除上个封面的缓存与沉浸背景：防止 coverglass 背景残留上一首歌的模糊封面
-                    blurredCoverUrl.value = '';
-                    isSmtcCoverActive.value = false;
-                    blurredCoverCache.clear();
-                    coverCache.clear();
+                    if (artist == "potplayer") { // PotPlayer视频模式
+                        coverUrl.value = potplayerLogo;
+                        // 清除上个封面的缓存与沉浸背景：防止 coverglass 背景残留上一首歌的模糊封面
+                        blurredCoverUrl.value = '';
+                        isSmtcCoverActive.value = false;
+                        blurredCoverCache.clear();
+                        coverCache.clear();
+                    }
                 }
 
                 // 仅在 WS 不活跃时，发起 HTTP 网络歌词兜底（PotPlayer 不拉歌词，标题常驻）


### PR DESCRIPTION
**PR 日志**：首先新增 `prefer_smtc` 参数控制是否优先使用 SMTC 本地封面，并增加应用包名状态跟踪以处理应用切换场景，适配 PotPlayer 音乐模式强制走网络封面而非本地 SMTC 封面，同时修复歌词刷新时机，应用切换时立即兜底拉取歌词（`11f5606`）。其次修复灵动岛隐藏后物理窗口残留拦截点击的问题，添加隐藏后延迟隐藏物理窗口的逻辑，并在调整窗口位置时跳过非显示状态窗口调用，避免透明窗口残留拦截鼠标事件（`f42af20`）。最后调整歌词获取引擎的调用顺序，将 LRCLIB 歌词引擎从网易云兜底前调整为兜底后执行，优化获取优先级，先尝试网易云接口再以 LRCLIB 作为补充（`09f4297`）。