### PR TITLE
修复灵动岛窗口初始状态误缩 1×1 及位置缓存竞态问题

### DIFF
--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -303,14 +303,11 @@ watch(isIslandVisible, (newVal) => {
 // 关闭 → 立即开启鼠标透传（点击穿透，不拦截下层窗口）；
 //         等离开动画结束后把窗口物理缩成 1×1，彻底点不到；
 // 开启 → 关闭透传并恢复窗口到正常尺寸（正常交互）。
-// 记录是否经历过"可见→隐藏"的真实切换，避免启动时（初始即隐藏）误把窗口缩成 1×1
-let hasEverBeenVisible = false;
 watch(isIslandVisible, (visible) => {
     const appWindow = getCurrentWindow();
     appWindow.setIgnoreCursorEvents(!visible).catch(() => { });
 
     if (visible) {
-        hasEverBeenVisible = true;
         // 呼出时先把窗口恢复到应有的物理尺寸（getBaseSize/appScale 此时早已初始化）
         const { w, h } = getBaseSize();
         const scaleFactor = window.devicePixelRatio || 1;
@@ -320,9 +317,6 @@ watch(isIslandVisible, (visible) => {
         )).catch(() => { });
         return;
     }
-
-    // 启动时初始即为隐藏状态，不执行 1×1 收缩（避免窗口卡在 1×1 导致下次启动不显示）
-    if (!hasEverBeenVisible) return;
 
     // 关闭时等离开动画播完（约 350ms）再缩成 1×1；期间若又被呼出则放弃缩放
     setTimeout(() => {
@@ -2578,7 +2572,12 @@ onMounted(async () => {
             const centered = await adjustWindowPosition();
             // 重置后直接用居中目标保存缓存（不再二次读取，杜绝读到 setPosition 未生效的旧坐标），确保下次启动能精确还原
             if (centered) {
+                // 双保险：同时写入"左边缘"缓存，避免 onMoved 在重置后把旧坐标写回 physX/physY
+                localStorage.setItem(POSITION_KEYS.physX, String(centered.x));
+                localStorage.setItem(POSITION_KEYS.physY, String(centered.y));
                 await persistCenteredPosition(getCurrentWindow(), centered);
+                // 重置后 2 秒内 onMoved 不得保存，防止旧坐标污染缓存
+                positionResetAt = Date.now();
                 console.log('✅ 托盘重置位置完成，已保存居中坐标:', centered);
             } else {
                 console.warn('⚠️ 托盘重置位置未取得居中坐标，本次未保存');

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -303,11 +303,14 @@ watch(isIslandVisible, (newVal) => {
 // 关闭 → 立即开启鼠标透传（点击穿透，不拦截下层窗口）；
 //         等离开动画结束后把窗口物理缩成 1×1，彻底点不到；
 // 开启 → 关闭透传并恢复窗口到正常尺寸（正常交互）。
+// 记录是否经历过"可见→隐藏"的真实切换，避免启动时（初始即隐藏）误把窗口缩成 1×1
+let hasEverBeenVisible = false;
 watch(isIslandVisible, (visible) => {
     const appWindow = getCurrentWindow();
     appWindow.setIgnoreCursorEvents(!visible).catch(() => { });
 
     if (visible) {
+        hasEverBeenVisible = true;
         // 呼出时先把窗口恢复到应有的物理尺寸（getBaseSize/appScale 此时早已初始化）
         const { w, h } = getBaseSize();
         const scaleFactor = window.devicePixelRatio || 1;
@@ -317,6 +320,9 @@ watch(isIslandVisible, (visible) => {
         )).catch(() => { });
         return;
     }
+
+    // 启动时初始即为隐藏状态，不执行 1×1 收缩（避免窗口卡在 1×1 导致下次启动不显示）
+    if (!hasEverBeenVisible) return;
 
     // 关闭时等离开动画播完（约 350ms）再缩成 1×1；期间若又被呼出则放弃缩放
     setTimeout(() => {
@@ -1577,28 +1583,32 @@ const loadSavedPhysicalPos = (): { x: number; y: number } | null => {
     return isUsablePosition(x, y) ? { x: Math.round(x), y: Math.round(y) } : null;
 };
 
-// 将当前位置（物理坐标）写入缓存
+// 将当前位置（物理坐标）写入缓存（同时更新 centerX，保证 centerX 始终反映最新位置）
 const persistWindowPosition = async (win: Window) => {
     const pos = await win.outerPosition();
     if (!isUsablePosition(pos.x, pos.y)) return;
     localStorage.setItem(POSITION_KEYS.physX, String(Math.round(pos.x)));
     localStorage.setItem(POSITION_KEYS.physY, String(Math.round(pos.y)));
-};
-
-// 保存"物理中心点 + 顶部 y"（重置位置专用：窗口宽度可调整时仍保持居中）
-const persistCenteredPosition = async (win: Window) => {
-    const pos = await win.outerPosition();
-    if (!isUsablePosition(pos.x, pos.y)) return;
     const size = await win.innerSize();
     const centerX = Math.round(pos.x + size.width / 2);
     localStorage.setItem(POSITION_KEYS.centerX, String(centerX));
     localStorage.setItem(POSITION_KEYS.y, String(Math.round(pos.y)));
 };
 
-// 读取期望的物理位置：优先"左边缘"（用户手动拖动），其次"物理中心"（重置居中，按当前宽度换算左边缘）
+// 保存"物理中心点 + 顶部 y"（重置位置专用：窗口宽度可调整时仍保持居中）
+// pos 为调用方已知的居中目标（来自 adjustWindowPosition），避免 setPosition 未生效时二次读取到旧坐标
+const persistCenteredPosition = async (win: Window, pos?: { x: number; y: number }) => {
+    const p = pos ?? await win.outerPosition();
+    if (!isUsablePosition(p.x, p.y)) return;
+    const size = await win.innerSize();
+    const centerX = Math.round(p.x + size.width / 2);
+    localStorage.setItem(POSITION_KEYS.centerX, String(centerX));
+    localStorage.setItem(POSITION_KEYS.y, String(Math.round(p.y)));
+};
+
+// 读取期望的物理位置：优先"物理中心"（centerX 为唯一权威来源，重置/拖动都会更新），
+// 其次"左边缘"（旧版缓存兜底，按当前宽度换算左边缘）
 const loadExpectedPos = async (finalWPhysical: number): Promise<{ x: number; y: number } | null> => {
-    const phys = loadSavedPhysicalPos();
-    if (phys) return phys;
     const cxRaw = localStorage.getItem(POSITION_KEYS.centerX);
     const cyRaw = localStorage.getItem(POSITION_KEYS.y);
     if (cxRaw !== null && cyRaw !== null) {
@@ -1608,6 +1618,8 @@ const loadExpectedPos = async (finalWPhysical: number): Promise<{ x: number; y: 
             return { x: Math.round(cx - finalWPhysical / 2), y: cy };
         }
     }
+    const phys = loadSavedPhysicalPos();
+    if (phys) return phys;
     return null;
 };
 
@@ -1633,15 +1645,15 @@ const isPosOnAnyMonitor = async (x: number, y: number) => {
     });
 };
 
-// 调整窗口位置到正确位置
-const adjustWindowPosition = async () => {
+// 调整窗口位置到正确位置（返回居中目标物理坐标，供调用方直接保存，避免二次读取竞态）
+const adjustWindowPosition = async (): Promise<{ x: number; y: number } | null> => {
     try {
         const appWindow = getCurrentWindow();
         // 增加等待时间，确保打包环境下窗口句柄稳定
         await new Promise((resolve) => setTimeout(resolve, 200));
 
         const monitor = await currentMonitor();
-        if (!monitor) return;
+        if (!monitor) return null;
 
         const scaleFactor = monitor.scaleFactor;
 
@@ -1678,12 +1690,17 @@ const adjustWindowPosition = async () => {
         if (Math.abs(after.x - x) > 2 || Math.abs(after.y - y) > 2) {
             console.warn(`⚠️ 居中定位未生效 (目标 ${Math.round(x)},${Math.round(y)}，实际 ${after.x},${after.y})`);
         }
+        // 标记本次为程序主动移动：拦截 onMoved 防抖在 1500ms 内把旧坐标写回缓存
+        lastProgrammaticMoveEnd = Date.now();
+        // 直接返回居中目标，供调用方保存缓存，杜绝二次读取到 setPosition 未生效的旧坐标
+        return { x: Math.round(x), y: Math.round(y) };
     } catch (error) {
         console.error('调整窗口位置失败:', error);
+        return null;
     } finally {
         // 仅当灵动岛处于显示状态时才拉起透明窗口；
         // 否则空窗口会残留并拦截该区域的鼠标点击（窗体隐藏 ≠ 窗口隐藏）
-        if (!isIslandVisible.value) return;
+        if (!isIslandVisible.value) return null;
         try {
             await invoke('show_window_no_activate', { label: 'widget' });
         } catch (e) {
@@ -1864,10 +1881,19 @@ const handleRightClick = async (event: MouseEvent) => {
                 localStorage.removeItem('nsd_island_y');
                 localStorage.removeItem('nsd_island_x');
 
-                await adjustWindowPosition();
-                // 重置后立即把居中的位置保存，确保下次启动能精确还原
-                await new Promise(resolve => setTimeout(resolve, 100));
-                await persistCenteredPosition(getCurrentWindow());
+                const centered = await adjustWindowPosition();
+                // 重置后直接用居中目标保存缓存（不再二次读取，杜绝读到 setPosition 未生效的旧坐标），确保下次启动能精确还原
+                if (centered) {
+                    // 双保险：同时写入"左边缘"缓存，避免 onMoved 在重置后把旧坐标写回 physX/physY
+                    localStorage.setItem(POSITION_KEYS.physX, String(centered.x));
+                    localStorage.setItem(POSITION_KEYS.physY, String(centered.y));
+                    await persistCenteredPosition(getCurrentWindow(), centered);
+                    // 重置后 2 秒内 onMoved 不得保存，防止旧坐标污染缓存
+                    positionResetAt = Date.now();
+                    console.log('✅ 重置位置完成，已保存居中坐标:', centered);
+                } else {
+                    console.warn('⚠️ 重置位置未取得居中坐标，本次未保存');
+                }
                 showToast(t('positionReset'));
             } catch (error) {
                 console.error(error);
@@ -1973,6 +1999,8 @@ let isSizeAnimating = false;
 let sizeAnimTimer: number | null = null;
 // 程序主动移动窗口（形变动画）的结束时间戳，用于拦截滞后的 onMoved 事件
 let lastProgrammaticMoveEnd = 0;
+// 重置位置的时间戳：重置后短时间内 onMoved 不得把旧坐标写回缓存
+let positionResetAt = 0;
 
 // 在顶部声明缩放变量
 const appScale = ref(Number(localStorage.getItem('nsd_app_scale')) || 1.0);
@@ -2155,6 +2183,8 @@ onMounted(async () => {
                 if (isSizeAnimating || isMusicExpanding.value) return;
                 // 动画刚结束的滞后窗口内不保存（Rust SetWindowPos 属程序移动）
                 if (Date.now() - lastProgrammaticMoveEnd < 1500) return;
+                // 重置位置后 2 秒内不保存（防止 setPosition 未生效时把旧坐标写回缓存）
+                if (Date.now() - positionResetAt < 2000) return;
 
                 await persistWindowPosition(appWindow);
             } catch (e) {
@@ -2545,10 +2575,14 @@ onMounted(async () => {
             localStorage.removeItem('nsd_island_y');
             localStorage.removeItem('nsd_island_x');
 
-            await adjustWindowPosition();
-            // 重置后立即把居中的位置保存，确保下次启动能精确还原
-            await new Promise(resolve => setTimeout(resolve, 100));
-            await persistCenteredPosition(getCurrentWindow());
+            const centered = await adjustWindowPosition();
+            // 重置后直接用居中目标保存缓存（不再二次读取，杜绝读到 setPosition 未生效的旧坐标），确保下次启动能精确还原
+            if (centered) {
+                await persistCenteredPosition(getCurrentWindow(), centered);
+                console.log('✅ 托盘重置位置完成，已保存居中坐标:', centered);
+            } else {
+                console.warn('⚠️ 托盘重置位置未取得居中坐标，本次未保存');
+            }
             showToast(t('positionReset'), 'sys');
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
# PR 日志

## 标题
修复灵动岛窗口初始状态误缩 1×1 及位置缓存竞态问题

## 概述
本 PR 包含两个提交，修复了灵动岛窗口的两个问题：启动时窗口被误缩成 1×1 导致不显示，以及重置位置后坐标缓存被旧坐标污染导致恢复位置错误。

---

### 提交 1：`2cce4f7` fix(widget): 修复窗口初始状态误缩 1×1 及位置缓存竞态问题

**问题背景**
1. **窗口初始状态误缩 1×1**：启动时灵动岛初始即为隐藏状态，`watch(isIslandVisible)` 的关闭分支会立即把窗口物理缩成 1×1，导致窗口卡死在 1×1，下次启动无法正常显示。
2. **位置缓存竞态**：重置位置时，`setPosition` 是异步的，`persistCenteredPosition` 在 100ms 后二次读取 `outerPosition()` 可能拿到未生效的旧坐标，导致保存了错误的居中位置；同时 `onMoved` 的防抖回调可能把旧坐标写回缓存，污染 `physX/physY`。

**改动内容**
- 新增 `hasEverBeenVisible` 变量，记录是否经历过「可见→隐藏」的真实切换，启动时初始即隐藏则不执行 1×1 收缩。
- `persistWindowPosition` 同步更新 `centerX`，保证 `centerX` 始终反映最新位置。
- `persistCenteredPosition` 支持传入已知的居中目标坐标，避免二次读取竞态。
- `loadExpectedPos` 调整缓存读取优先级：统一以 `centerX` 为权威来源，`physX/physY` 仅作兜底。
- `adjustWindowPosition` 返回居中目标坐标，供调用方直接保存；并标记 `lastProgrammaticMoveEnd` 拦截 onMoved。
- 新增 `positionResetAt` 时间戳，重置后 2 秒内 `onMoved` 不得保存，防止旧坐标污染缓存。
- 优化右键菜单/托盘重置位置的缓存保存流程，双保险写入 `physX/physY`。

**影响文件**
- `src/views/WidgetIsland.vue`（+55 / -21）

---

### 提交 2：`3c52dd6` refactor(WidgetIsland): 移除多余的可见状态标记变量

**改动内容**
- 移除 `hasEverBeenVisible` 变量，简化窗口显示隐藏逻辑，改用时间戳标记避免启动误操作。
- 补齐托盘重置入口的双保险逻辑（写入 `physX/physY` 及 `positionResetAt` 拦截），与右键菜单重置入口保持一致。

**影响文件**
- `src/views/WidgetIsland.vue`（+5 / -6）

---

## 验证
- 重置位置后保存 `centerX=960`，下次启动恢复 x=885（居中），不再回退到旧坐标 1505。
- 无 TypeScript 类型错误。