### PR TITLE
修复落雪音乐（lx-music）支持+区分"音乐"和"视频"播放源+长标题滚动动画

### DIFF
--- a/src-tauri/src/music_controller.rs
+++ b/src-tauri/src/music_controller.rs
@@ -81,6 +81,12 @@ fn get_target_media_session() -> Option<(GlobalSystemMediaTransportControlsSessi
             {
                 return Some((session, app_id_str));
             }
+            // 落雪音乐：包名可能叫 lx 或 lx-music
+            else if target == "lx-music"
+                && (app_id_str.contains("cn.toside.music.desktop") || app_id_str.contains("lx-music"))
+            {
+                return Some((session, app_id_str));
+            }
             // 其他软件直接用名字去系统进程列表里撞
             else if target != "netease" && app_id_str.contains(&target) {
                 return Some((session, app_id_str));

--- a/src-tauri/src/music_controller.rs
+++ b/src-tauri/src/music_controller.rs
@@ -81,7 +81,7 @@ fn get_target_media_session() -> Option<(GlobalSystemMediaTransportControlsSessi
             {
                 return Some((session, app_id_str));
             }
-            // 落雪音乐：包名可能叫 lx 或 lx-music
+            // 落雪音乐：包名叫 cn.toside.music.desktop，用lx-music作为备用包名
             else if target == "lx-music"
                 && (app_id_str.contains("cn.toside.music.desktop") || app_id_str.contains("lx-music"))
             {

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -1503,6 +1503,14 @@ watch(displayMusic, async () => {
             scrollDist.value = 0;
         }
     }, 100);
+    // 尺寸形变动画（约 500ms）结束后再算一次：
+    // 消息通知消失回到媒体折叠态时，若折叠态宽度缓存尚未建立（collapsedMaskWidth 为 0），
+    // 首次计算会因容器仍处于消息宽度而误判为无需滚动；动画结束后用稳定宽度重算即可恢复滚动
+    setTimeout(() => {
+        if (displayMusic.value) {
+            calculateScroll();
+        }
+    }, 600);
 });
 
 let lastRx = 0;
@@ -2078,6 +2086,9 @@ const onInnerLeave = (el: Element, done: () => void) => {
 // 记录全局灵动岛是否正在执行形变动画
 let isSizeAnimating = false;
 let sizeAnimTimer: number | null = null;
+// 形变请求序号：用于串行化 animateIslandSize，保证「最新一次请求」永远接管动画，
+// 避免旧动画（如正在进行的收缩）在异步读取窗口尺寸后覆盖新状态（如消息展开）
+let latestAnimationRequest = 0;
 // 程序主动移动窗口（形变动画）的结束时间戳，用于拦截滞后的 onMoved 事件
 let lastProgrammaticMoveEnd = 0;
 // 重置位置的时间戳：重置后短时间内 onMoved 不得把旧坐标写回缓存
@@ -2093,6 +2104,7 @@ watch(appScale, (newScale) => {
 
 // 灵动岛核心代码！（完美防漂移+防裁切+防打断抖动）
 const animateIslandSize = async (targetWidth: number, targetHeight: number) => {
+    const myRequest = ++latestAnimationRequest;
     try {
         // 核心：计算最终的缩放尺寸
         const finalWidth = targetWidth * appScale.value;
@@ -2109,6 +2121,11 @@ const animateIslandSize = async (targetWidth: number, targetHeight: number) => {
 
         const appWindow = getCurrentWindow();
         const realSize = await appWindow.innerSize();
+
+        // 若在异步读取窗口尺寸期间，又有更新的尺寸请求到来，则放弃本次，
+        // 让最新请求接管动画，避免旧动画覆盖新状态（如收缩动画覆盖消息展开）
+        if (myRequest !== latestAnimationRequest) return;
+
         const scaleFactor = window.devicePixelRatio;
 
         const realStartW = realSize.width / scaleFactor;
@@ -2149,6 +2166,10 @@ const collapseMusic = () => {
         clearTimeout(musicExpandAnimTimer);
         musicExpandAnimTimer = null;
     }
+
+    // 消息通知正在显示时，只复位媒体展开状态，不收缩岛体尺寸，
+    // 否则会把正在展示的消息压回折叠尺寸（消息应保持消息展开宽度）
+    if (isMsgActive.value) return;
 
     const { w, h } = getBaseSize();
     animateIslandSize(w, h);
@@ -2715,6 +2736,14 @@ onMounted(async () => {
 
                 if (!isMsgActive.value) {
                     isMsgActive.value = true;
+                    // 消息接管时复位媒体展开状态：避免消息消失后音乐盒以展开态显示在折叠尺寸上
+                    isMusicExpanded.value = false;
+                    isMusicExpanding.value = false;
+                    // 若媒体正在展开动画中，取消其定时器，防止稍后把 isMusicExpanded 重新置回 true
+                    if (musicExpandAnimTimer) {
+                        clearTimeout(musicExpandAnimTimer);
+                        musicExpandAnimTimer = null;
+                    }
                     animateIslandSize(nsdMsgExpandedWidth.value, 65);
                 }
 

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -117,8 +117,14 @@
                                         </transition>
                                     </div>
                                     <div class="music-info-text double-line" :class="{ 'fade-in': isMusicExpanded }">
-                                        <div class="song-title">{{ currentSongName }}</div>
-                                        <div class="song-artist">{{ currentArtistName }}</div>
+                                        <div class="song-title" ref="expandedTitleBoxRef">
+                                            <span class="scroll-inner" ref="expandedTitleRef"
+                                                :class="{ 'is-scrolling': expandedTitleScrollDist > 0 }"
+                                                :style="{ '--scroll-dist': expandedTitleScrollDist + 'px', '--scroll-duration': expandedTitleScrollDuration }">
+                                                {{ currentSongName }}
+                                            </span>
+                                        </div>
+                                        <div class="song-artist" v-show="!isVideoLikeSource">{{ currentArtistName }}</div>
                                     </div>
                                 </div>
                             </div>
@@ -606,6 +612,8 @@ const coverCache = new Map<string, string>();
 // 当前播放器是否为浏览器（edge/chrome），以及是否正在展示 SMTC 本地封面
 const currentIsBrowser = ref(false);
 const isSmtcCoverActive = ref(false);
+// 浏览器是否成功获取到封面/歌词（成功即视为播放音乐，而非视频）
+const isBrowserMusic = ref(false);
 // 当前 SMTC 来源应用的包名（用于 PotPlayer 音乐模式等封面策略判断）
 const currentAppIdStr = ref('');
 
@@ -764,6 +772,11 @@ const fillCollapsedWithTrackInfo = () => {
         setSafeTrackInfo(currentSongName.value);
         return;
     }
+    // 视频类播放源（B站/浏览器视频）：只显示标题，不拼歌手
+    if (isVideoLikeSource.value) {
+        setSafeTrackInfo(currentSongName.value);
+        return;
+    }
     const artist = currentArtistName.value === t('unknownArtist') ? '' : currentArtistName.value;
     setSafeTrackInfo(artist ? `${currentSongName.value} - ${artist}` : currentSongName.value);
 };
@@ -818,6 +831,9 @@ const initWebSocket = async () => {
                         lyricQueue.value = [];
                         currentMatchedIndex = -1;
                         lastLyricChangeTime = 0; // 重置时间锁，允许立刻显示第一句歌词
+
+                        // 浏览器收到完整歌词 → 判定为播放音乐（而非视频）
+                        if (currentIsBrowser.value) isBrowserMusic.value = true;
 
                         return;
                     }
@@ -1063,7 +1079,7 @@ const syncMusicStatus = async () => {
 
         if (res) {
             const [song, artist, playing, positionMs, durationMs, app_id_str] = res;
-
+            console.log('syncMusicStatus', song, artist, playing, positionMs, durationMs, app_id_str);
             // 记录当前是否为浏览器类应用（edge/chrome），供封面刷新逻辑区分处理
             currentIsBrowser.value =
                 app_id_str.includes("edge") || app_id_str.includes("chrome");
@@ -1114,6 +1130,9 @@ const syncMusicStatus = async () => {
 
             if (currentBaseInfo.value !== newTrackInfo) {
                 currentBaseInfo.value = newTrackInfo;
+
+                // 切歌时重置浏览器音乐判定，等封面/歌词获取结果再确认是音乐还是视频
+                isBrowserMusic.value = false;
 
                 // 切歌时，第一时间重置本地时间轴！
                 if (!isWsActive) {
@@ -1180,6 +1199,8 @@ const syncMusicStatus = async () => {
                             if (appSwitched || Date.now() - lastWsLyricTime > 3000) {
                                 if (lrc) {
                                     parsedLyrics.value = parseLrc(lrc);
+                                    // 浏览器拉到歌词 → 判定为播放音乐（而非视频）
+                                    if (currentIsBrowser.value) isBrowserMusic.value = true;
                                     // 刚拉到歌词时，如果发现时长还是 0，立刻补救
                                     if (currentDurationMs.value <= 0 && parsedLyrics.value.length > 0) {
                                         const lastLyric = parsedLyrics.value[parsedLyrics.value.length - 1];
@@ -1263,6 +1284,24 @@ const currentTrackInfo = ref(`${t('noSongPlaying')} - ${getPlayerName()}`);
 // 此时不做歌词匹配，直接用标题当常驻歌词显示
 const isPotplayerSource = computed(() => currentArtistName.value === 'potplayer');
 
+// 视频类播放源（B站/浏览器视频/PotPlayer视频）：只显示标题、不显示歌手，标题滚动放慢
+const isVideoLikeSource = computed(() => {
+    // PotPlayer 视频模式：始终作为视频类
+    if (isPotplayerSource.value) return true;
+    // B站：始终作为视频类
+    if (currentAppIdStr.value.includes('bilibili')) return true;
+    // 浏览器：成功获取到封面/歌词即视为播放音乐，否则视为播放视频
+    if (currentIsBrowser.value) return !isBrowserMusic.value;
+    return false;
+});
+
+// 浏览器音乐/视频判定变化时，重新填充折叠态文本（音乐显示"标题 - 歌手"，视频只显示标题）
+watch(isVideoLikeSource, () => {
+    if (displayMusic.value && currentSongName.value !== t('noSongPlaying')) {
+        fillCollapsedWithTrackInfo();
+    }
+});
+
 watch(currentLanguage, () => {
     if (!displayMusic.value || currentSongName.value === t('noSongPlaying')) {
         currentSongName.value = t('noSongPlaying');
@@ -1326,6 +1365,47 @@ const maskBoxRef = ref<HTMLElement | null>(null);
 const textInnerRef = ref<HTMLElement | null>(null);
 const scrollDist = ref(0);
 const scrollDuration = ref('0s');
+
+// 展开态标题（B站/浏览器视频等长标题）滚动相关变量
+const expandedTitleBoxRef = ref<HTMLElement | null>(null);
+const expandedTitleRef = ref<HTMLElement | null>(null);
+const expandedTitleScrollDist = ref(0);
+const expandedTitleScrollDuration = ref('0s');
+
+// 计算展开态标题是否需要滚动：标题超出容器宽度时，以固定速度来回滚动
+const calculateExpandedTitleScroll = () => {
+    if (!expandedTitleRef.value || !expandedTitleBoxRef.value) return;
+    const textWidth = expandedTitleRef.value.getBoundingClientRect().width;
+    const containerWidth = expandedTitleBoxRef.value.clientWidth;
+    if (textWidth > containerWidth) {
+        // 把文字末尾拖到最右，外加 5px 呼吸空间
+        expandedTitleScrollDist.value = Math.ceil(textWidth - containerWidth + 5);
+        // 固定 20px/s 的滚动速度（视频类标题放慢），来回 ping-pong（滚动占 70%，开头/末尾各停 15%）
+        const timeToMove = expandedTitleScrollDist.value / 20;
+        expandedTitleScrollDuration.value = `${(timeToMove / 0.7).toFixed(2)}s`;
+    } else {
+        expandedTitleScrollDist.value = 0;
+    }
+};
+
+// 标题变化、展开/折叠切换、或音乐/视频判定变化时，重新计算展开态标题的滚动
+watch([currentSongName, isMusicExpanded, isVideoLikeSource], async () => {
+    await nextTick();
+    // 点击展开立即计算一次，让标题马上开始滚动（此时容器还是折叠态宽度，滚动距离偏大）
+    if (isMusicExpanded.value) {
+        calculateExpandedTitleScroll();
+    } else {
+        expandedTitleScrollDist.value = 0;
+    }
+    // 等 0.4s 宽度过渡 + 形变动画结束再量一次，用稳定后的宽度修正滚动距离
+    setTimeout(() => {
+        if (isMusicExpanded.value) {
+            calculateExpandedTitleScroll();
+        } else {
+            expandedTitleScrollDist.value = 0;
+        }
+    }, 500);
+});
 
 // 获取当前歌词句的演唱时长（毫秒），用于动态滚动调速
 const getCurrentLineDuration = (): number => {
@@ -1392,10 +1472,17 @@ const calculateScroll = () => {
         // 由纯滚动时间反推总动画时长（纯滚动占 70%）
         let totalDuration = safeTimeToMove / 0.7;
 
-        // 滚到底的保证：动画总时长不得超过本句展示时长。
-        // 否则长句被 90px/s 钳制 / 4.5s 保底拉长后，还没滚到末尾就被下一句顶掉，
-        // 表现为「有时候歌词滚不到底」。文字在展示期内即可滚完并停住结尾。
-        totalDuration = Math.max(Math.min(totalDuration, displayWindowSec), 0.8);
+        // 视频类播放源（B站/浏览器视频）：标题常驻不随歌词变化，用固定慢速滚动，
+        // 且不受歌词展示时长限制，让长标题从容滚完再回来
+        if (isVideoLikeSource.value) {
+            const slowTimeToMove = scrollDist.value / 20;
+            totalDuration = slowTimeToMove / 0.7;
+        } else {
+            // 滚到底的保证：动画总时长不得超过本句展示时长。
+            // 否则长句被 90px/s 钳制 / 4.5s 保底拉长后，还没滚到末尾就被下一句顶掉，
+            // 表现为「有时候歌词滚不到底」。文字在展示期内即可滚完并停住结尾。
+            totalDuration = Math.max(Math.min(totalDuration, displayWindowSec), 0.8);
+        }
 
         scrollDuration.value = `${totalDuration.toFixed(2)}s`;
     } else {
@@ -3390,7 +3477,6 @@ onUnmounted(() => {
     margin-bottom: 2px;
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
     line-height: 1.2;
     width: 100%;
     text-align: left !important;


### PR DESCRIPTION
# PR 日志

### 1. 修复落雪音乐（lx-music）支持
- 灵动岛现在能识别并匹配落雪音乐播放器，正确显示其播放状态。

### 2. 区分"音乐"和"视频"播放源
- 之前浏览器播放视频时，灵动岛会误当成音乐显示歌手、歌词。
- 现在能自动判断：PotPlayer 视频、B 站、浏览器视频只显示标题，不显示歌手；只有真正播放音乐时才显示歌手和歌词。

### 3. 长标题滚动动画
- 歌曲标题太长时，展开态会自动滚动展示，视频类标题滚动更慢，方便看清完整标题。

### 4. 修复灵动岛动画冲突
- 修复了消息通知弹出时，灵动岛尺寸被错误收缩、动画互相覆盖的问题，让消息和音乐盒的切换更稳定。

### 5. 修复滚动判断错误
- 修复了首次显示消息时歌词/标题滚动判断错误的问题，动画结束后会重新计算滚动距离。

---

## 提交 1：`39c0f3f` — feat: 新增落雪音乐支持，优化音乐/视频播放源区分与长标题滚动

**改动文件：**
- `src-tauri/src/music_controller.rs`（+6）
- `src/views/WidgetIsland.vue`（+96 / -8）

**改动内容：**

1. **落雪音乐（lx/lx-music）SMTC 会话匹配支持**
   - 在 `get_target_media_session` 中新增对 `lx-music` 目标的匹配分支，通过包名 `cn.toside.music.desktop` 或 `lx-music` 识别落雪音乐。

2. **新增 `isVideoLikeSource` 计算属性区分音乐/视频播放源**
   - PotPlayer 视频模式、B 站（bilibili）始终视为视频类。
   - 浏览器（edge/chrome）：成功获取到封面/歌词即视为播放音乐，否则视为播放视频。
   - 新增 `isBrowserMusic` 状态，在切歌时重置，在拉取到歌词或收到完整歌词时置为 `true`。

3. **为展开态歌曲标题添加长文本滚动动画**
   - 新增 `expandedTitleBoxRef` / `expandedTitleRef` 等变量与 `calculateExpandedTitleScroll` 函数。
   - 标题超出容器宽度时以固定 20px/s 速度 ping-pong 滚动，视频类标题放慢。
   - 监听标题变化、展开/折叠切换、音乐/视频判定变化时重新计算滚动。

4. **针对视频类播放源优化显示逻辑**
   - 视频类仅显示标题、不显示歌手（`v-show="!isVideoLikeSource"`）。
   - 折叠态文本填充逻辑：视频类只填标题，不拼接歌手。

5. **调整歌曲信息折叠态填充逻辑与滚动动画策略**
   - 歌词滚动：视频类用固定慢速滚动且不受歌词展示时长限制；普通音乐保持原有"滚动到底保证"逻辑。
   - 移除 `.song-title` 的 `text-overflow: ellipsis`，改为滚动展示。

---

## 提交 2：`8cd7594` — fix(desktop-widget): 修复灵动岛动画状态冲突和尺寸计算问题

**改动文件：**
- `src-tauri/src/music_controller.rs`（+1 / -1）
- `src/views/WidgetIsland.vue`（+29）

**改动内容：**

1. **更新落雪音乐的包名匹配规则**
   - 使用官方包名 `cn.toside.music.desktop` 作为主匹配，`lx-music` 作为备用包名。

2. **添加动画请求序号机制，避免旧动画覆盖新的灵动岛尺寸状态**
   - 新增 `latestAnimationRequest` 序号变量，`animateIslandSize` 每次调用自增。
   - 在异步读取窗口尺寸后校验序号，若期间有更新的尺寸请求到来则放弃本次，让最新请求接管动画，避免旧动画（如正在进行的收缩）覆盖新状态（如消息展开）。

3. **修复消息激活时误收缩岛体的问题**
   - `collapseMusic` 中新增判断：消息通知正在显示时只复位媒体展开状态，不收缩岛体尺寸，避免把正在展示的消息压回折叠尺寸。

4. **添加动画结束后的滚动重算，修复首次显示消息时的滚动判断错误**
   - 在 `displayMusic` 监听中新增 600ms 延时重算滚动，解决消息通知消失回到媒体折叠态时，因折叠态宽度缓存尚未建立（`collapsedMaskWidth` 为 0）导致首次计算误判为无需滚动的问题。
   - 消息接管时复位媒体展开状态并取消展开动画定时器，避免消息消失后音乐盒以展开态显示在折叠尺寸中。
