### PR TITLE
fix: 优化浏览器应用识别和抖音歌曲过滤逻辑

### DIFF
--- a/src-tauri/src/music_controller.rs
+++ b/src-tauri/src/music_controller.rs
@@ -153,6 +153,10 @@ pub async fn fetch_netease_music_info(
 
     let mut position_ms: i64 = 0;
     let mut duration_ms: i64 = 0; // 新增：用于记录歌曲总时长
+    
+    if title.contains("抖音") || title.contains("douyin") { // 识别到抖音
+        return Ok(None);
+    }
 
     if let Ok(timeline) = session.GetTimelineProperties() {
         if let Ok(pos) = timeline.Position() {
@@ -187,11 +191,21 @@ pub async fn fetch_netease_music_info(
     }
     
     if app_id_str.contains("edge") { // 识别到 Edge 浏览器
-        return Ok(Some((title, "edge".to_string(), is_playing, position_ms, duration_ms, app_id_str)));
+        if artist.is_empty() {
+            return Ok(Some((title, "edge".to_string(), is_playing, position_ms, duration_ms, app_id_str)));
+        }
+        else {
+            return Ok(Some((title, artist, is_playing, position_ms, duration_ms, app_id_str)));
+        }
     }
 
     if app_id_str.contains("chrome") { // 识别到 Chrome 浏览器
-        return Ok(Some((title, "chrome".to_string(), is_playing, position_ms, duration_ms, app_id_str)));
+        if artist.is_empty() {
+            return Ok(Some((title, "chrome".to_string(), is_playing, position_ms, duration_ms, app_id_str)));
+        }
+        else {
+            return Ok(Some((title, artist, is_playing, position_ms, duration_ms, app_id_str)));
+        }
     }
 
     if app_id_str.contains("potplayer") { // 识别到 PotPlayer

--- a/src/views/WidgetIsland.vue
+++ b/src/views/WidgetIsland.vue
@@ -1081,8 +1081,12 @@ const syncMusicStatus = async () => {
             const [song, artist, playing, positionMs, durationMs, app_id_str] = res;
             console.log('syncMusicStatus', song, artist, playing, positionMs, durationMs, app_id_str);
             // 记录当前是否为浏览器类应用（edge/chrome），供封面刷新逻辑区分处理
-            currentIsBrowser.value =
+            
+            if (artist === "edge" || artist === "chrome") {
+                currentIsBrowser.value =
                 app_id_str.includes("edge") || app_id_str.includes("chrome");
+            }
+
             // 检测 SMTC 来源应用是否发生了切换（应用包名变更），用于及时刷新歌词
             const appSwitched = currentAppIdStr.value !== '' && currentAppIdStr.value !== app_id_str;
             // 记录当前 SMTC 来源应用的包名，供恢复播放时的封面刷新逻辑判断


### PR DESCRIPTION
1. 修复浏览器应用的artist字段传递问题，保留原有artist值而非硬编码
2. 新增抖音歌曲过滤，直接跳过识别抖音音源
3. 调整浏览器应用判断的条件逻辑